### PR TITLE
Add Tkinter GUI for grant wrangler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # grant-manager-tool-demo
+
+Utility repository containing `wrangle_grants.py` for merging and normalizing grant CSV/TSV files.
+An optional `wrangle_grants_gui.py` provides a minimal Tkinter interface to run the wrangler without the command line.
+
+See [README_wrangle_grants.md](README_wrangle_grants.md) for usage instructions.

--- a/README_wrangle_grants.md
+++ b/README_wrangle_grants.md
@@ -1,0 +1,40 @@
+# CSV → Clean Master Wrangling
+
+This script merges many grant CSV/TSV files into **one clean master** with a consistent schema, normalized deadlines/money, deduplication, and a **Weighted Score** column.
+
+## Quick Start
+
+```bash
+# 1) Put all your CSV/TSV files in a folder
+mkdir -p data/csvs
+# (drop files into data/csvs)
+
+# 2) Run the script (adjust paths as needed)
+python wrangle_grants.py --input data/csvs --out out/master.csv --xlsx out/master.xlsx --weights 0.4 0.4 0.2 --deadline-cutoff today --print-summary
+```
+
+## GUI Option
+
+For a basic desktop interface instead of the command line, run:
+
+```bash
+python wrangle_grants_gui.py
+```
+
+The window lets you choose folders and output paths, tweak weights, set a deadline cutoff, and run the wrangler.
+
+## What it does (in plain English)
+
+* Scans a folder of CSV/TSV files → merges into **one clean master**
+* Normalizes headers into your **Clean Table** schema
+* Parses **money** (Award max/min/Total funding) and **dates** (Deadline)
+* Computes **Weighted Score** from Relevance, EQORE Fit, Ease of Use (weights configurable)
+* Adds **Days to Deadline** + **Expired** flags
+* Deduplicates by **Grant name + Sponsor org**
+* Sorts by **Weighted Score (desc)** then **Deadline (asc)**
+* Exports **CSV** (and optional **Excel**)
+
+## Notes
+
+* It already recognizes lots of messy header names (e.g., “Opportunity Title,” “Award Ceiling,” “Close Date”).
+* If you spot columns it didn’t map, tell me the exact header text and I’ll add them to the alias list so your next run is perfect.

--- a/wrangle_grants.py
+++ b/wrangle_grants.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+Wrangle many grant CSVs into one clean master.
+
+Usage:
+    python wrangle_grants.py --input ./data/csvs --out ./out/master.csv --xlsx ./out/master.xlsx \
+        --weights 0.4 0.4 0.2 --deadline-cutoff today
+
+Notes:
+- Requires: Python 3.9+, pandas, openpyxl (for .xlsx output).
+- No internet access required.
+- You can safely run it multiple times; it will re-create outputs.
+"""
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, date
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+
+# -------------------- Configuration --------------------
+
+# Canonical schema
+CANON_COLS = [
+    "Grant name",
+    "Sponsor org",
+    "Link",
+    "Award max",
+    "Award min",
+    "Funding instrument",
+    "Eligibility",
+    "Period of performance",
+    "Deadline",
+    "Total funding",
+    "Relevance",
+    "EQORE Fit",
+    "Ease of Use",
+    "Weighted Score",
+    "Status",
+    "Notes",
+]
+
+# Column alias map: maps lowercase/stripped input headers to canonical column names
+ALIASES: Dict[str, str] = {
+    # Grant name
+    "grant name": "Grant name",
+    "opportunity title": "Grant name",
+    "title": "Grant name",
+    "program name": "Grant name",
+    "funding opportunity title": "Grant name",
+
+    # Sponsor org
+    "sponsor org": "Sponsor org",
+    "agency": "Sponsor org",
+    "sponsoring agency": "Sponsor org",
+    "organization": "Sponsor org",
+    "sponsor": "Sponsor org",
+    "department": "Sponsor org",
+
+    # Link
+    "link": "Link",
+    "url": "Link",
+    "opportunity link": "Link",
+    "grant link": "Link",
+    "program link": "Link",
+    "opportunity url": "Link",
+
+    # Award max/min
+    "award max": "Award max",
+    "maximum award": "Award max",
+    "award ceiling": "Award max",
+    "ceiling": "Award max",
+    "award maximum": "Award max",
+    "award min": "Award min",
+    "minimum award": "Award min",
+    "award floor": "Award min",
+    "floor": "Award min",
+
+    # Funding instrument
+    "funding instrument": "Funding instrument",
+    "instrument": "Funding instrument",
+    "funding type": "Funding instrument",
+
+    # Eligibility
+    "eligibility": "Eligibility",
+    "eligible applicants": "Eligibility",
+    "who may apply": "Eligibility",
+    "applicant eligibility": "Eligibility",
+
+    # Period of performance
+    "period of performance": "Period of performance",
+    "project period": "Period of performance",
+    "period": "Period of performance",
+    "duration": "Period of performance",
+
+    # Deadline
+    "deadline": "Deadline",
+    "application deadline": "Deadline",
+    "close date": "Deadline",
+    "closing date": "Deadline",
+    "due date": "Deadline",
+    "submission deadline": "Deadline",
+
+    # Total funding
+    "total funding": "Total funding",
+    "estimated total program funding": "Total funding",
+    "funding available": "Total funding",
+
+    # Scores
+    "relevance": "Relevance",
+    "eqore fit": "EQORE Fit",
+    "fit": "EQORE Fit",
+    "ease of use": "Ease of Use",
+    "ease": "Ease of Use",
+
+    # Status/Notes
+    "status": "Status",
+    "notes": "Notes",
+    "extra notes": "Notes",
+    "special notes": "Notes",
+}
+
+
+MONEY_COLS = {"Award max", "Award min", "Total funding"}
+
+
+def norm_header(h: str) -> str:
+    return re.sub(r"\s+", " ", h.strip().lower())
+
+
+def map_columns(df: pd.DataFrame) -> pd.DataFrame:
+    mapped = {}
+    for col in df.columns:
+        key = norm_header(str(col))
+        mapped[col] = ALIASES.get(key, col)  # keep original if unknown
+    df = df.rename(columns=mapped)
+
+    # Only keep columns that overlap canonical OR are clearly useful
+    keep_cols = set(CANON_COLS) & set(df.columns)
+    # Always keep any unexpected columns under Notes (later we can merge text)
+    extras = [c for c in df.columns if c not in CANON_COLS]
+
+    # If we have extras, we will concatenate them into Notes
+    notes_parts = []
+    for c in extras:
+        # skip entirely empty columns
+        if df[c].notna().any():
+            notes_parts.append(f"{c}: " + df[c].astype(str))
+
+    out = pd.DataFrame()
+    for c in CANON_COLS:
+        if c in keep_cols:
+            out[c] = df[c]
+        else:
+            out[c] = pd.NA
+
+    if notes_parts:
+        notes_series = notes_parts[0]
+        for s in notes_parts[1:]:
+            notes_series = notes_series.fillna("") + " | " + s.fillna("")
+        out["Notes"] = out["Notes"].fillna("") + " | " + notes_series.fillna("")
+        out["Notes"] = out["Notes"].str.strip(" |")
+
+    return out
+
+
+def parse_money(x) -> Optional[float]:
+    if pd.isna(x):
+        return None
+    if isinstance(x, (int, float)):
+        return float(x)
+    s = str(x)
+    s = s.replace(",", "")
+    m = re.search(r"(-?\d+(\.\d+)?)", s)
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except Exception:
+        return None
+
+
+def normalize_money(df: pd.DataFrame) -> pd.DataFrame:
+    for c in MONEY_COLS:
+        if c in df.columns:
+            df[c] = df[c].apply(parse_money)
+    return df
+
+
+def normalize_deadline(df: pd.DataFrame) -> pd.DataFrame:
+    if "Deadline" not in df.columns:
+        return df
+    df["Deadline"] = pd.to_datetime(df["Deadline"], errors="coerce", infer_datetime_format=True, utc=True)
+    # keep as date (no time)
+    df["Deadline"] = df["Deadline"].dt.tz_convert(None)
+    return df
+
+
+def compute_weighted(df: pd.DataFrame, w_relevance: float, w_fit: float, w_ease: float) -> pd.DataFrame:
+    for col in ["Relevance", "EQORE Fit", "Ease of Use"]:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors="coerce").clip(lower=0, upper=5)
+
+    total = w_relevance + w_fit + w_ease
+    if total == 0:
+        total = 1.0
+    wr = w_relevance / total
+    wf = w_fit / total
+    we = w_ease / total
+
+    df["Weighted Score"] = (df["Relevance"] * wr + df["EQORE Fit"] * wf + df["Ease of Use"] * we).round(3)
+    return df
+
+
+def add_deadline_helpers(df: pd.DataFrame) -> pd.DataFrame:
+    if "Deadline" not in df.columns:
+        return df
+    today = pd.Timestamp.today().normalize()
+    df["Days to Deadline"] = (df["Deadline"] - today).dt.days
+    df["Expired"] = df["Days to Deadline"].apply(lambda d: bool(d is not None and pd.notna(d) and d < 0))
+    return df
+
+
+def deduplicate(df: pd.DataFrame) -> pd.DataFrame:
+    # Simple key: Grant name + Sponsor org (case-insensitive)
+    key_cols = []
+    for c in ["Grant name", "Sponsor org"]:
+        if c not in df.columns:
+            df[c] = pd.NA
+        key_cols.append(c)
+
+    key_series = (
+        df["Grant name"].astype(str).str.strip().str.lower().fillna("")
+        + " | "
+        + df["Sponsor org"].astype(str).str.strip().str.lower().fillna("")
+    )
+    # Keep the first occurrence (prefer non-null rows by sorting)
+    sort_cols = []
+    if "Deadline" in df.columns:
+        sort_cols.append(("Deadline", True))
+    if "Weighted Score" in df.columns:
+        sort_cols.append(("Weighted Score", False))
+
+    if sort_cols:
+        by = [c for c, _ in sort_cols]
+        ascending = [asc for _, asc in sort_cols]
+        df = df.sort_values(by=by, ascending=ascending, na_position="last")
+
+    # Drop duplicates based on the key
+    df["_key"] = key_series
+    df = df.drop_duplicates(subset=["_key"], keep="first").drop(columns=["_key"])
+    return df
+
+
+def filter_deadlines(df: pd.DataFrame, cutoff: Optional[str]) -> pd.DataFrame:
+    if not cutoff or "Deadline" not in df.columns:
+        return df
+
+    today = pd.Timestamp.today().normalize()
+
+    if cutoff.lower() == "today":
+        return df[df["Deadline"].isna() | (df["Deadline"] >= today)]
+
+    try:
+        dt = pd.to_datetime(cutoff, errors="coerce")
+        if pd.isna(dt):
+            return df
+        dt = pd.Timestamp(dt.date())
+        return df[df["Deadline"].isna() | (df["Deadline"] >= dt)]
+    except Exception:
+        return df
+
+
+def read_csv_safe(path: Path) -> Optional[pd.DataFrame]:
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        # Try TSV
+        try:
+            return pd.read_csv(path, sep="\t")
+        except Exception:
+            return None
+
+
+def load_folder(folder: Path) -> List[pd.DataFrame]:
+    frames: List[pd.DataFrame] = []
+    for p in folder.rglob("*"):
+        if p.suffix.lower() in {".csv", ".tsv", ".tab"}:
+            df = read_csv_safe(p)
+            if df is not None and len(df):
+                df["_source_file"] = str(p)
+                frames.append(df)
+    return frames
+
+
+def ensure_columns(df: pd.DataFrame) -> pd.DataFrame:
+    for c in CANON_COLS:
+        if c not in df.columns:
+            df[c] = pd.NA
+    return df[CANON_COLS + [c for c in df.columns if c not in CANON_COLS]]
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", type=str, required=True, help="Folder containing .csv/.tsv files")
+    ap.add_argument("--out", type=str, required=True, help="Output master CSV path")
+    ap.add_argument("--xlsx", type=str, default="", help="Optional Excel output path")
+    ap.add_argument("--weights", type=float, nargs=3, default=[0.4, 0.4, 0.2], help="Weights: relevance fit ease")
+    ap.add_argument("--deadline-cutoff", type=str, default="", help="Keep items with Deadline >= this date (YYYY-MM-DD) or 'today'")
+    ap.add_argument("--print-summary", action="store_true", help="Print a quick summary to stdout")
+    args = ap.parse_args(argv)
+
+    in_folder = Path(args.input)
+    out_csv = Path(args.out)
+    out_xlsx = Path(args.xlsx) if args.xlsx else None
+
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    if out_xlsx:
+        out_xlsx.parent.mkdir(parents=True, exist_ok=True)
+
+    frames = load_folder(in_folder)
+    if not frames:
+        raise SystemExit(f"No CSV/TSV files found in {in_folder}")
+
+    # Map each to canonical, then concat
+    mapped_frames = []
+    for df in frames:
+        m = map_columns(df)
+        mapped_frames.append(m)
+
+    all_df = pd.concat(mapped_frames, ignore_index=True)
+
+    # Normalize values
+    all_df = normalize_money(all_df)
+    all_df = normalize_deadline(all_df)
+
+    # Compute weights
+    w_rel, w_fit, w_ease = args.weights
+    all_df = compute_weighted(all_df, w_rel, w_fit, w_ease)
+
+    # Helpers
+    all_df = add_deadline_helpers(all_df)
+    all_df = deduplicate(all_df)
+    all_df = filter_deadlines(all_df, args.deadline_cutoff)
+
+    # Ensure canonical columns are present and ordered
+    all_df = ensure_columns(all_df)
+
+    # Sort by Weighted Score desc, then Deadline asc
+    sort_cols = []
+    if "Weighted Score" in all_df.columns:
+        sort_cols.append(("Weighted Score", False))
+    if "Deadline" in all_df.columns:
+        sort_cols.append(("Deadline", True))
+
+    if sort_cols:
+        by = [c for c, _ in sort_cols]
+        ascending = [asc for _, asc in sort_cols]
+        all_df = all_df.sort_values(by=by, ascending=ascending, na_position="last")
+
+    # Write outputs
+    all_df.to_csv(out_csv, index=False)
+    if out_xlsx:
+        try:
+            all_df.to_excel(out_xlsx, index=False)
+        except Exception as e:
+            print(f"WARNING: Could not write Excel file: {e}")
+
+    if args.print_summary:
+        total = len(all_df)
+        n_expired = int(all_df.get("Expired", pd.Series([False]*total)).sum())
+        top5 = all_df.head(5)[["Grant name", "Sponsor org", "Deadline", "Weighted Score"]]
+        print(f"Rows: {total} | Expired: {n_expired}")
+        try:
+            print(top5.to_string(index=False))
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/wrangle_grants_gui.py
+++ b/wrangle_grants_gui.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Simple Tkinter interface for wrangle_grants.
+Allows selecting input/output paths, adjusting weights, and running the
+wrangler without command-line usage.
+"""
+
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+import wrangle_grants
+
+
+# ----------------- UI callbacks -----------------
+
+def run_wrangler():
+    input_dir = input_var.get().strip()
+    csv_out = csv_var.get().strip()
+    xlsx_out = xlsx_var.get().strip()
+    w1 = w1_var.get().strip() or "0.4"
+    w2 = w2_var.get().strip() or "0.4"
+    w3 = w3_var.get().strip() or "0.2"
+    cutoff = cutoff_var.get().strip()
+
+    argv = ["--input", input_dir, "--out", csv_out,
+            "--weights", w1, w2, w3]
+    if xlsx_out:
+        argv.extend(["--xlsx", xlsx_out])
+    if cutoff:
+        argv.extend(["--deadline-cutoff", cutoff])
+    if summary_var.get():
+        argv.append("--print-summary")
+
+    def task():
+        try:
+            wrangle_grants.main(argv)
+            messagebox.showinfo("Grant Wrangler", "Wrangling complete.")
+        except Exception as e:
+            messagebox.showerror("Grant Wrangler", str(e))
+
+    threading.Thread(target=task, daemon=True).start()
+
+
+def browse_dir():
+    d = filedialog.askdirectory()
+    if d:
+        input_var.set(d)
+
+
+def browse_csv():
+    f = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV", "*.csv")])
+    if f:
+        csv_var.set(f)
+
+
+def browse_xlsx():
+    f = filedialog.asksaveasfilename(defaultextension=".xlsx", filetypes=[("Excel", "*.xlsx")])
+    if f:
+        xlsx_var.set(f)
+
+
+# ----------------- Build UI -----------------
+
+root = tk.Tk()
+root.title("Grant CSV Wrangler")
+
+input_var = tk.StringVar()
+csv_var = tk.StringVar()
+xlsx_var = tk.StringVar()
+w1_var = tk.StringVar(value="0.4")
+w2_var = tk.StringVar(value="0.4")
+w3_var = tk.StringVar(value="0.2")
+cutoff_var = tk.StringVar()
+summary_var = tk.BooleanVar(value=False)
+
+# Row 0: input folder
+tk.Label(root, text="Input folder").grid(row=0, column=0, sticky="e")
+tk.Entry(root, textvariable=input_var, width=40).grid(row=0, column=1)
+tk.Button(root, text="Browse", command=browse_dir).grid(row=0, column=2)
+
+# Row 1: output csv
+tk.Label(root, text="Output CSV").grid(row=1, column=0, sticky="e")
+tk.Entry(root, textvariable=csv_var, width=40).grid(row=1, column=1)
+tk.Button(root, text="Browse", command=browse_csv).grid(row=1, column=2)
+
+# Row 2: output xlsx
+tk.Label(root, text="Output XLSX").grid(row=2, column=0, sticky="e")
+tk.Entry(root, textvariable=xlsx_var, width=40).grid(row=2, column=1)
+tk.Button(root, text="Browse", command=browse_xlsx).grid(row=2, column=2)
+
+# Row 3: weights
+tk.Label(root, text="Weights (rel, fit, ease)").grid(row=3, column=0, sticky="e")
+tk.Entry(root, textvariable=w1_var, width=5).grid(row=3, column=1, sticky="w")
+tk.Entry(root, textvariable=w2_var, width=5).grid(row=3, column=2, sticky="w")
+tk.Entry(root, textvariable=w3_var, width=5).grid(row=3, column=3, sticky="w")
+
+# Row 4: cutoff
+tk.Label(root, text="Deadline cutoff").grid(row=4, column=0, sticky="e")
+tk.Entry(root, textvariable=cutoff_var, width=10).grid(row=4, column=1, sticky="w")
+
+# Row 5: summary checkbox
+tk.Checkbutton(root, text="Print summary", variable=summary_var).grid(row=5, column=1, sticky="w")
+
+# Row 6: run button
+tk.Button(root, text="Run", command=run_wrangler).grid(row=6, column=1, pady=10)
+
+root.mainloop()


### PR DESCRIPTION
## Summary
- expose argv-based entrypoint in `wrangle_grants.py` for reuse
- add `wrangle_grants_gui.py` Tkinter interface to run the wrangler without CLI
- document GUI option in README files

## Testing
- `python -m py_compile wrangle_grants.py wrangle_grants_gui.py`
- `python wrangle_grants.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python wrangle_grants_gui.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas openpyxl` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b7220237f48332824d3edb6f15569b