### PR TITLE
docs: add beginner installation notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@ An optional `wrangle_grants_gui.py` provides a minimal Tkinter interface to run 
 
 See [README_wrangle_grants.md](README_wrangle_grants.md) for usage instructions.
 
+## Beginner installation
+
+If you're new to Python or Node.js, the following steps walk through a fresh
+setup of the project:
+
+1. Install [Python 3.9+](https://www.python.org/downloads/) and
+   [Node.js](https://nodejs.org/) if they are not already on your machine.
+2. Clone the repository and change into the project directory:
+
+   ```bash
+   git clone https://github.com/your-org/grant-manager-tool-demo.git
+   cd grant-manager-tool-demo
+   ```
+3. Create and activate a Python virtual environment, then install the
+   dependencies:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+4. (Optional) Install Node dependencies for the Cloudflare Worker example:
+
+   ```bash
+   npm install
+   ```
+
+After these steps the `wrangle_grants.py` script and the optional Cloudflare
+Worker demo can be run using the commands shown below.
+
 ## Python environment
 
 The wrangling scripts require Python 3.9+ with `pandas` and `openpyxl`.


### PR DESCRIPTION
## Summary
- add beginner-friendly installation section to README with step-by-step Python and Node setup instructions

## Testing
- `npm test` (fails: Missing script: 'test')
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b736e484f083328f0a0f57089a035c