### PR TITLE
Show scored data immediately after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ pip install -r requirements.txt
 
 A minimal Cloudflare Worker is provided for quickly publishing a demo endpoint.
 The worker includes a basic login page (credentials match the GUI: `admin/adminpass` and
-`user/userpass`) and, once logged in, loads scored opportunities from a CSV file
-(`out/master.csv` by default). The data is rendered in a table and, when the CSV
-contains `Name` and `Weighted Score` columns, a bar chart is also shown. Update the
-`CSV_URL` constant in `worker.js` if your scored CSV is hosted elsewhere. To deploy:
+`user/userpass`) and, once logged in, redirects to `/scored` to display the scored
+opportunities from a CSV file (`out/master.csv` by default). The data is rendered in a
+table and, when the CSV contains `Name` and `Weighted Score` columns, a bar chart is also
+shown. Update the `CSV_URL` constant in `worker.js` if your scored CSV is hosted elsewhere.
+To deploy:
 
 ```bash
 npm install            # install wrangler locally

--- a/worker.js
+++ b/worker.js
@@ -42,7 +42,10 @@ function loginPage() {
 </html>`;
 }
 
-function dashboardPage(grants) {
+// Render a simple table (and optional bar chart) of scored grant data.
+// The page name now reflects that it specifically visualizes the scored CSV
+// rather than being a generic dashboard.
+function scoredPage(grants) {
   const headers = grants.length ? Object.keys(grants[0]) : [];
   const headerRow = headers.map((h) => `<th>${h}</th>`).join('');
   const rows = grants
@@ -83,11 +86,11 @@ function dashboardPage(grants) {
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Grant Dashboard</title>
+  <title>Scored Grants</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-  <h1>Grant Dashboard</h1>
+  <h1>Scored Grants</h1>
   <a href="/logout">Logout</a>
   <table border="1">
     <tr>${headerRow}</tr>
@@ -111,7 +114,7 @@ export default {
       if (users[user] === pass) {
         return new Response('', {
           status: 302,
-          headers: { 'Set-Cookie': 'session=active; Path=/', Location: '/dashboard' }
+          headers: { 'Set-Cookie': 'session=active; Path=/', Location: '/scored' }
         });
       }
       return new Response('Unauthorized', { status: 401 });
@@ -122,7 +125,17 @@ export default {
         return new Response('', { status: 302, headers: { Location: '/' } });
       }
       const grants = await fetchGrantsFromCsv();
-      return new Response(dashboardPage(grants), {
+      return new Response(scoredPage(grants), {
+        headers: { 'content-type': 'text/html; charset=UTF-8' }
+      });
+    }
+
+    if (url.pathname === '/scored') {
+      if (!loggedIn) {
+        return new Response('', { status: 302, headers: { Location: '/' } });
+      }
+      const grants = await fetchGrantsFromCsv();
+      return new Response(scoredPage(grants), {
         headers: { 'content-type': 'text/html; charset=UTF-8' }
       });
     }


### PR DESCRIPTION
## Summary
- Add dedicated `scoredPage` with table and chart of weighted scores
- Redirect login to `/scored` and expose new route for scored data view
- Update README to mention scored view after authentication

## Testing
- `node --check worker.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b763bb582c83329b4726607fbf1742