### PR TITLE
Improve wrangle_grants defaults and path prompting

### DIFF
--- a/wrangle_grants.py
+++ b/wrangle_grants.py
@@ -307,18 +307,46 @@ def ensure_columns(df: pd.DataFrame) -> pd.DataFrame:
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
-    ap.add_argument("--input", type=str, required=True, help="Folder containing .csv/.tsv files")
-    ap.add_argument("--out", type=str, required=True, help="Output master CSV path")
+    ap.add_argument(
+        "--input",
+        type=str,
+        default="",
+        help="Folder containing .csv/.tsv files (default: data/csvs)",
+    )
+    ap.add_argument(
+        "--out",
+        type=str,
+        default="",
+        help="Output master CSV path (default: out/master.csv)",
+    )
     ap.add_argument("--xlsx", type=str, default="", help="Optional Excel output path")
     ap.add_argument("--weights", type=float, nargs=3, default=[0.4, 0.4, 0.2], help="Weights: relevance fit ease")
     ap.add_argument("--deadline-cutoff", type=str, default="", help="Keep items with Deadline >= this date (YYYY-MM-DD) or 'today'")
     ap.add_argument("--print-summary", action="store_true", help="Print a quick summary to stdout")
     args = ap.parse_args(argv)
 
+    default_in = Path("data/csvs")
+    default_out = Path("out/master.csv")
 
-    in_folder = Path(args.input)
-    out_csv = Path(args.out)
+    in_str = args.input.strip()
+    if not in_str:
+        in_str = input(f"Input folder [{default_in}]: ").strip()
+    if not in_str:
+        in_str = str(default_in)
+
+    out_str = args.out.strip()
+    if not out_str:
+        out_str = input(f"Output master CSV path [{default_out}]: ").strip()
+    if not out_str:
+        out_str = str(default_out)
+
+    in_folder = Path(in_str)
+    out_csv = Path(out_str)
     out_xlsx = Path(args.xlsx) if args.xlsx else None
+
+    if in_folder == default_in and not in_folder.exists():
+        in_folder.mkdir(parents=True, exist_ok=True)
+        print(f"Created default input folder at {in_folder.resolve()}")
 
     out_csv.parent.mkdir(parents=True, exist_ok=True)
     if out_xlsx:


### PR DESCRIPTION
## Summary
- Make --input and --out optional with defaults
- Prompt interactively for empty paths and create default input folder

## Testing
- `python -m py_compile wrangle_grants.py`


------
https://chatgpt.com/codex/tasks/task_e_68b777956b688332a486071cf383a22a