### PR TITLE
Add demo grant CSVs and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ username: user    password: userpass
 
 See [README_wrangle_grants.md](README_wrangle_grants.md) for usage instructions.
 
+## Sample dataset
+
+A tiny dataset is included under `examples/grants_demo` for quick testing. Run
+the wrangler against it to see normalization and scoring in action:
+
+```bash
+python wrangle_grants.py --input examples/grants_demo --out out/demo.csv --print-summary
+```
+
+This command merges the demo files, computes weighted scores, and writes the
+result to `out/demo.csv`.
+
 ## Browser visualization
 
 For a quick way to explore wrangled data in your browser, run the small Flask

--- a/README_wrangle_grants.md
+++ b/README_wrangle_grants.md
@@ -33,6 +33,17 @@ or
 wrangle_grants.py --input data/csvs --out out/master.csv --xlsx out/master.xlsx --weights 0.4 0.4 0.2 --deadline-cutoff today --print-summary
 ```
 
+## Sample data
+
+Tiny demo CSVs live in `examples/grants_demo`. Run the wrangler on them to see
+parsing of money, deadlines, and scores:
+
+```bash
+python3 wrangle_grants.py --input examples/grants_demo --out out/demo.csv --print-summary
+```
+
+This merges the sample files and writes `out/demo.csv`.
+
 ## GUI Option
 
 For a basic desktop interface instead of the command line, run:

--- a/examples/grants_demo/alpha.csv
+++ b/examples/grants_demo/alpha.csv
@@ -1,0 +1,2 @@
+Grant name,Sponsor org,Link,Deadline,Award max,Award min,Total funding,Relevance,EQORE Fit,Ease of Use
+Alpha Research Grant,Alpha Org,https://alpha.example.com,2024-12-31,50000,10000,200000,0.8,0.9,0.7

--- a/examples/grants_demo/beta.csv
+++ b/examples/grants_demo/beta.csv
@@ -1,0 +1,2 @@
+Grant name,Sponsor org,Deadline,Award max,Relevance,EQORE Fit,Ease of Use
+Beta Community Grant,Beta Org,2025-01-15,25000,0.6,0.5,0.9


### PR DESCRIPTION
## Summary
- add tiny sample grant CSVs under `examples/grants_demo`
- document how to run the wrangler on the sample dataset in main and wrangling READMEs

## Testing
- `pytest -q`
- `python wrangle_grants.py --input examples/grants_demo --out out/demo.csv --print-summary`


------
https://chatgpt.com/codex/tasks/task_e_68b7779b0d6c8332805a420496c80f78