### PR TITLE
Add dashboard schema entry form and display

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -27,6 +27,13 @@ const programsCsv =
   "Type,Name,Sponsor,Source URL,Region / Eligibility,Deadline / Next Cohort,Cadence,Benefits,Eligibility (key conditions),Stage,Non-dilutive?,Stack Required?,Relevance,Fit,Ease,Weighted Score,Notes / Actions\n" +
   "program,Workers Launchpad,Cloudflare,https://www.cloudflare.com/lp/workers-launchpad/,Global; startups built on Workers,Quarterly cohorts; Demo Days; rolling intake,Quarterly,VC intros (40+ firms); founder bootcamps; Cloudflare engineering office hours; PM previews; community & Demo Day,Built core infra on Cloudflare Workers,Pre-seed–Series A,No (VC intros; not a grant),Yes (Workers required),5,5,5,,Confirm Workers usage; prepare 5-min pitch + traction bullets; follow cohort announcements";
 
+// Initialize entries from the sample CSV and store new ones in memory.
+const schemaEntries = programsCsv
+  .split("\n")
+  .slice(1)
+  .filter((r) => r.trim())
+  .map((row) => row.split(","));
+
 function loginPage() {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -44,17 +51,39 @@ function loginPage() {
 
 function dashboardPage() {
   const headerRow = schemaColumns.map((h) => `<th>${h}</th>`).join("");
+  const bodyRows = schemaEntries
+    .map((entry) => `<tr>${entry.map((c) => `<td>${c}</td>`).join("")}</tr>`)
+    .join("");
   return `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"><title>Dashboard</title></head>
 <body>
   <h1>Program Data Schema</h1>
-  <table border="1"><thead><tr>${headerRow}</tr></thead></table>
+  <p><a href="/new_schema">Add schema entry</a></p>
+  <table border="1"><thead><tr>${headerRow}</tr></thead><tbody>${bodyRows}</tbody></table>
   <p>
     <a href="/schema">View schema JSON</a> |
     <a href="/data">Sample CSV</a> |
     <a href="/logout">Logout</a>
   </p>
+</body>
+</html>`;
+}
+
+function newSchemaPage() {
+  const inputs = schemaColumns
+    .map((c) => `<label>${c} <input name="${c}" /></label><br />`)
+    .join("\n");
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>New Schema Entry</title></head>
+<body>
+  <h1>Add Schema Entry</h1>
+  <form method="POST" action="/new_schema">
+    ${inputs}
+    <button type="submit">Save</button>
+  </form>
+  <p><a href="/dashboard">Back to dashboard</a></p>
 </body>
 </html>`;
 }
@@ -89,6 +118,27 @@ export default {
         });
       }
       return new Response(dashboardPage(), {
+        headers: { "content-type": "text/html; charset=UTF-8" },
+      });
+    }
+
+    if (url.pathname === "/new_schema") {
+      if (!loggedIn) {
+        return new Response("", {
+          status: 302,
+          headers: { Location: "/" },
+        });
+      }
+      if (request.method === "POST") {
+        const form = await request.formData();
+        const entry = schemaColumns.map((c) => form.get(c) || "");
+        schemaEntries.push(entry);
+        return new Response("", {
+          status: 302,
+          headers: { Location: "/dashboard" },
+        });
+      }
+      return new Response(newSchemaPage(), {
         headers: { "content-type": "text/html; charset=UTF-8" },
       });
     }


### PR DESCRIPTION
## Summary
- Render program entries on the dashboard and link to an entry creation form
- Provide `/new_schema` page to add schema entries via HTML form
- Store new entries in memory and show them on subsequent dashboard visits

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check worker.js`

------
https://chatgpt.com/codex/tasks/task_e_68b7a5c6100c8332a46c226490eceae1