### PR TITLE
Secure worker login

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@ The GUI now starts with a simple login screen demonstrating "admin" and
 "user" roles. The admin account can adjust weighting and deadline fields
 while the standard user can only choose files and run the wrangler.
 
-Default credentials:
+Credentials are supplied via a `USER_HASHES` environment variable containing
+SHA-256 password hashes. Example:
 
 ```
-username: admin   password: adminpass
-username: user    password: userpass
+export USER_HASHES='{"admin":"<sha256 hash>","user":"<sha256 hash>"}'
+```
+
+Hashes can be generated with tools such as `sha256sum`:
+
+```
+echo -n "adminpass" | sha256sum
 ```
 
 See [README_wrangle_grants.md](README_wrangle_grants.md) for usage instructions.
@@ -88,10 +94,10 @@ pip install -r requirements.txt
 ## Cloudflare Worker demo
 
 A minimal Cloudflare Worker is provided for quickly publishing a demo endpoint.
-The worker includes a basic login page (credentials match the GUI: `admin/adminpass` and
-`user/userpass`).
-After logging in, the `/dashboard` view renders the program data schema table, with
-links to `/schema` (JSON) and `/data` (CSV) for alternate views.
+The worker includes a basic login page configured via the `USER_HASHES`
+environment variable. After logging in, the `/dashboard` view renders the
+program data schema table, with links to `/schema` (JSON) and `/data` (CSV)
+for alternate views.
 
 ## Developer guide
 

--- a/worker.js
+++ b/worker.js
@@ -1,7 +1,14 @@
-const users = {
-  admin: "adminpass",
-  user: "userpass",
-};
+const loginAttempts = new Map();
+const MAX_ATTEMPTS = 5;
+const LOCKOUT_MS = 5 * 60 * 1000;
+
+async function hashPassword(password) {
+  const data = new TextEncoder().encode(password);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
 
 const schemaColumns = [
   "Type",
@@ -60,24 +67,41 @@ function dashboardPage() {
 }
 
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
     const url = new URL(request.url);
     const cookie = request.headers.get("Cookie") || "";
     const loggedIn = cookie.includes("session=active");
+    const users = env.USER_HASHES ? JSON.parse(env.USER_HASHES) : {};
 
     if (url.pathname === "/login" && request.method === "POST") {
       const form = await request.formData();
       const user = form.get("username");
       const pass = form.get("password");
-      if (users[user] === pass) {
+      const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+      const now = Date.now();
+      const record = loginAttempts.get(ip) || { count: 0, time: now };
+      if (now - record.time > LOCKOUT_MS) {
+        record.count = 0;
+        record.time = now;
+      }
+      if (record.count >= MAX_ATTEMPTS) {
+        return new Response("Too many attempts. Try again later.", { status: 429 });
+      }
+      const hashed = await hashPassword(pass || "");
+      if (users[user] && users[user] === hashed) {
+        loginAttempts.delete(ip);
         return new Response("", {
           status: 302,
           headers: {
-            "Set-Cookie": "session=active; Path=/",
+            "Set-Cookie":
+              "session=active; Path=/; HttpOnly; Secure; SameSite=Lax",
             Location: "/dashboard",
           },
         });
       }
+      record.count++;
+      record.time = now;
+      loginAttempts.set(ip, record);
       return new Response("Unauthorized", { status: 401 });
     }
 
@@ -109,7 +133,8 @@ export default {
       return new Response("", {
         status: 302,
         headers: {
-          "Set-Cookie": "session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+          "Set-Cookie":
+            "session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax",
           Location: "/",
         },
       });


### PR DESCRIPTION
## Summary
- Load user credentials from a USER_HASHES environment variable with SHA-256 password hashes
- Add HttpOnly, Secure, and SameSite=Lax attributes to session cookies
- Introduce simple in-memory rate limiting to slow brute-force login attempts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a68bea5883329e28a3e792e3a661