### PR TITLE
refactor: separate worker HTML templates

### DIFF
--- a/templates/dashboard.js
+++ b/templates/dashboard.js
@@ -1,0 +1,22 @@
+export function renderDashboardPage(headers = [], rows = []) {
+  const headerRow = headers.map((h) => `<th>${h}</th>`).join("");
+  const bodyRows = rows
+    .map((cols) => `<tr>${cols.map((c) => `<td>${c}</td>`).join("")}</tr>`)
+    .join("");
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Dashboard</title></head>
+<body>
+  <h1>Program Data Schema</h1>
+  <table border="1">
+    <thead><tr>${headerRow}</tr></thead>
+    <tbody>${bodyRows}</tbody>
+  </table>
+  <p>
+    <a href="/schema">View schema JSON</a> |
+    <a href="/data">Sample CSV</a> |
+    <a href="/logout">Logout</a>
+  </p>
+</body>
+</html>`;
+}

--- a/templates/login.js
+++ b/templates/login.js
@@ -1,0 +1,14 @@
+export function renderLoginPage() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Grant Login</title></head>
+<body>
+  <h1>Grant Wrangler Demo</h1>
+  <form method="POST" action="/login">
+    <label>Username <input name="username" /></label><br />
+    <label>Password <input type="password" name="password" /></label><br />
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>`;
+}

--- a/worker.js
+++ b/worker.js
@@ -1,3 +1,11 @@
+import { renderLoginPage } from "./templates/login.js";
+import { renderDashboardPage } from "./templates/dashboard.js";
+
+/**
+ * HTML for the login and dashboard views lives in ./templates/.
+ * Update those files to modify UI markup without touching worker logic.
+ */
+
 const users = {
   admin: "adminpass",
   user: "userpass",
@@ -27,37 +35,11 @@ const programsCsv =
   "Type,Name,Sponsor,Source URL,Region / Eligibility,Deadline / Next Cohort,Cadence,Benefits,Eligibility (key conditions),Stage,Non-dilutive?,Stack Required?,Relevance,Fit,Ease,Weighted Score,Notes / Actions\n" +
   "program,Workers Launchpad,Cloudflare,https://www.cloudflare.com/lp/workers-launchpad/,Global; startups built on Workers,Quarterly cohorts; Demo Days; rolling intake,Quarterly,VC intros (40+ firms); founder bootcamps; Cloudflare engineering office hours; PM previews; community & Demo Day,Built core infra on Cloudflare Workers,Pre-seed–Series A,No (VC intros; not a grant),Yes (Workers required),5,5,5,,Confirm Workers usage; prepare 5-min pitch + traction bullets; follow cohort announcements";
 
-function loginPage() {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="UTF-8"><title>Grant Login</title></head>
-<body>
-  <h1>Grant Wrangler Demo</h1>
-  <form method="POST" action="/login">
-    <label>Username <input name="username" /></label><br />
-    <label>Password <input type="password" name="password" /></label><br />
-    <button type="submit">Login</button>
-  </form>
-</body>
-</html>`;
-}
-
-function dashboardPage() {
-  const headerRow = schemaColumns.map((h) => `<th>${h}</th>`).join("");
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="UTF-8"><title>Dashboard</title></head>
-<body>
-  <h1>Program Data Schema</h1>
-  <table border="1"><thead><tr>${headerRow}</tr></thead></table>
-  <p>
-    <a href="/schema">View schema JSON</a> |
-    <a href="/data">Sample CSV</a> |
-    <a href="/logout">Logout</a>
-  </p>
-</body>
-</html>`;
-}
+const programRows = programsCsv
+  .trim()
+  .split("\n")
+  .slice(1)
+  .map((line) => line.split(","));
 
 export default {
   async fetch(request) {
@@ -88,7 +70,7 @@ export default {
           headers: { Location: "/" },
         });
       }
-      return new Response(dashboardPage(), {
+      return new Response(renderDashboardPage(schemaColumns, programRows), {
         headers: { "content-type": "text/html; charset=UTF-8" },
       });
     }
@@ -115,7 +97,7 @@ export default {
       });
     }
 
-    return new Response(loginPage(), {
+    return new Response(renderLoginPage(), {
       headers: { "content-type": "text/html; charset=UTF-8" },
     });
   },


### PR DESCRIPTION
## Summary
- move login and dashboard markup into dedicated helper files
- render templates in worker.js by passing schema headers and sample rows
- document template locations for easier UI updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a68f240c83329381aaf51eb06680