### PR TITLE
feat: add PDF ingestion worker

### DIFF
--- a/worker/src/pdf_worker.ts
+++ b/worker/src/pdf_worker.ts
@@ -1,0 +1,49 @@
+export interface Env {
+  PDF_BUCKET: R2Bucket;
+  GRANT_SUMMARIZER_URL: string;
+  SCORE_QUEUE?: Queue;
+}
+
+export default {
+  async queue(batch: MessageBatch<any>, env: Env, ctx: ExecutionContext): Promise<void> {
+    for (const message of batch.messages) {
+      const body = typeof message.body === 'string' ? { key: message.body } : message.body;
+      const key = body?.key;
+      if (!key) {
+        console.error('Missing object key in message', message.body);
+        message.ack();
+        continue;
+      }
+
+      try {
+        const obj = await env.PDF_BUCKET.get(key);
+        if (!obj) {
+          console.error(`PDF not found: ${key}`);
+          message.ack();
+          continue;
+        }
+        const pdfArray = await obj.arrayBuffer();
+
+        const resp = await fetch(env.GRANT_SUMMARIZER_URL, {
+          method: 'POST',
+          headers: { 'content-type': 'application/pdf' },
+          body: pdfArray
+        });
+        if (!resp.ok) {
+          throw new Error(`summarizer status ${resp.status}`);
+        }
+        const { csv, markdown } = await resp.json();
+        const base = key.replace(/\.pdf$/i, '');
+        await env.PDF_BUCKET.put(`${base}.csv`, csv);
+        await env.PDF_BUCKET.put(`${base}.md`, markdown);
+        if (env.SCORE_QUEUE) {
+          await env.SCORE_QUEUE.send({ file: `${base}.csv` });
+        }
+        message.ack();
+      } catch (err) {
+        console.error('Failed to process message', err);
+        message.retry();
+      }
+    }
+  }
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -10,5 +10,16 @@ bucket = "./public"
 [observability.logs]
 enabled = false
 
+[[r2_buckets]]
+binding = "PDF_BUCKET"
+bucket_name = "PDF_BUCKET"
+
+[[queues.consumers]]
+queue = "PDF_INGEST"
+script = "pdf-worker"
+
+[workers.pdf-worker]
+main = "src/pdf_worker.ts"
+
 
 


### PR DESCRIPTION
## Summary
- configure `pdf-worker` to consume `PDF_INGEST` queue and access R2 bucket
- implement `pdf_worker.ts` to download PDFs, call summarizer, save CSV/Markdown, and enqueue scoring

## Testing
- `cd worker && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7a9410fd88332b52960c0eefbe7be