### PR TITLE
Add Wrangler config for worker with D1 binding

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+name = "grant-manager"
+main = "worker.js"
+compatibility_date = "2024-05-29"
+
+[vars]
+USER_HASHES = '{"admin":"713bfda78870bf9d1b261f565286f85e97ee614efe5f0faf7c34e7ca4f65baca","user":"05d49692b755f99c4504b510418efeeeebfd466892540f27acf9a31a326d6504"}'
+
+[[d1_databases]]
+binding = "DB"
+database_name = "EQORE_DB"
+database_id = "EQORE_DB"


### PR DESCRIPTION
## Summary
- Configure Cloudflare Worker by adding wrangler.toml
- Bind D1 database and user credential hashes for local development

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx wrangler dev --dry-run` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ab3789648332bdc84e1559c3230e