### PR TITLE
Handle empty program columns in worker queries

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -84,8 +84,11 @@ export default {
         });
       }
       const columns = await getColumns(env.DB);
+      const columnSql = columns.length
+        ? columns.map((c) => `"${c}"`).join(",")
+        : "*";
       const { results } = await env.DB.prepare(
-        `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
+        `SELECT ${columnSql} FROM programs`
       ).all();
       const rows = results.map((r) => columns.map((c) => r[c] ?? ""));
       return new Response(renderDashboardPage(columns, rows), {
@@ -130,8 +133,11 @@ export default {
 
     if (url.pathname === "/data") {
       const columns = await getColumns(env.DB);
+      const columnSql = columns.length
+        ? columns.map((c) => `"${c}"`).join(",")
+        : "*";
       const { results } = await env.DB.prepare(
-        `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
+        `SELECT ${columnSql} FROM programs`
       ).all();
       const body = [
         columns.join(","),


### PR DESCRIPTION
## Summary
- Safely build program queries by defaulting to `*` when no columns are returned
- Apply same logic for CSV `/data` endpoint to avoid `SELECT FROM` syntax error

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ae5e672c8332ad416883c961f703