### PR TITLE
Add run command column to AGENTS table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ This file describes the automation agents, their goals, inputs, outputs, and sch
 - Keep entries concise: use capitalized agent names, wrap file paths and commands in backticks, and limit each column to a single sentence.
 - Run `npm test` before committing to verify repository checks pass.
 
-| Agent | Goal | Inputs | Outputs | Schedule |
-|-------|------|--------|---------|----------|
-| GrantWrangler | Merge raw grant CSV files into a master dataset | `data/csvs/` | `out/master.csv` | Run `make wrangle` when new data arrives |
-| ProgramWatcher | Cloudflare worker for simple health checks | HTTP request to `/api/health` | JSON `{status:'ok', agent:'ProgramWatcher'}` | Always on |
-| ScoreWorker | Cloudflare worker that doubles a numeric value | POST to `/api/score` with `{value}` | JSON `{score}` | On demand |
-| Visualizer | Local web server to explore the master dataset | `out/master.csv` | Interactive web page | Run `make visualize` after data updates |
+| Agent | Goal | Inputs | Outputs | Run Command | Schedule |
+|-------|------|--------|---------|-------------|----------|
+| GrantWrangler | Merge raw grant CSV files into a master dataset | `data/csvs/` | `out/master.csv` | `make wrangle` | On new data arrival |
+| ProgramWatcher | Cloudflare worker for simple health checks | HTTP request to `/api/health` | JSON `{status:'ok', agent:'ProgramWatcher'}` | `npx wrangler dev --local` | Always on |
+| ScoreWorker | Cloudflare worker that doubles a numeric value | POST to `/api/score` with `{value}` | JSON `{score}` | `npx wrangler dev --local` | On demand |
+| Visualizer | Local web server to explore the master dataset | `out/master.csv` | Interactive web page | `make visualize` | After data updates |


### PR DESCRIPTION
## Summary
- add dedicated `Run Command` column with explicit commands for each agent
- clarify `Schedule` entries to show only timing information

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b17ba90c8332a14bd3dcdddfaba7