### PR TITLE
docs: add source paths for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
 # AGENTS.md — Asia’s Automation Crew
 
-This file describes the automation agents, their goals, inputs, outputs, schedules, and source paths.
+This file describes the automation agents, their goals, inputs, outputs, run commands, schedules, and source paths.
 
 ## Contributing
 
-- Update the table whenever a new agent is added or when an existing agent's goal, inputs, outputs, schedule, or source path changes.
+- Update the table whenever a new agent is added or when an existing agent's goal, inputs, outputs, run command, schedule, or source path changes.
 - Keep entries concise: use capitalized agent names, wrap file paths and commands in backticks, and limit each column to a single sentence.
 - Run `npm test` before committing to verify repository checks pass.
 
-| Agent | Goal | Inputs | Outputs | Schedule | Source |
-|-------|------|--------|---------|----------|--------|
-| GrantWrangler | Merge raw grant CSV files into a master dataset | `data/csvs/` | `out/master.csv` | Run `make wrangle` when new data arrives | Implemented in `wrangle_grants.py` |
-| ProgramWatcher | Cloudflare worker for simple health checks | HTTP request to `/api/health` | JSON `{status:'ok', agent:'ProgramWatcher'}` | Always on | Implemented in `workers/program_watcher_worker.js` |
-| ScoreWorker | Cloudflare worker that doubles a numeric value | POST to `/api/score` with `{value}` | JSON `{score}` | On demand | Implemented in `worker/src/worker.ts` |
-| Visualizer | Local web server to explore the master dataset | `out/master.csv` | Interactive web page | Run `make visualize` after data updates | Implemented in `visualize_grants_web.py` |
+| Agent | Goal | Inputs | Outputs | Run Command | Schedule | Source |
+|-------|------|--------|---------|-------------|----------|--------|
+| GrantWrangler | Merge raw grant CSV files into a master dataset | `data/csvs/` | `out/master.csv` | `make wrangle` | On new data arrival | `wrangle_grants.py` |
+| ProgramWatcher | Cloudflare worker for simple health checks | HTTP request to `/api/health` | JSON `{status:'ok', agent:'ProgramWatcher'}` | `npx wrangler dev --local` | Always on | `workers/program_watcher_worker.js` |
+| ScoreWorker | Cloudflare worker that doubles a numeric value | POST to `/api/score` with `{value}` | JSON `{score}` | `npx wrangler dev --local` | On demand | `worker/src/worker.ts` |
+| Visualizer | Local web server to explore the master dataset | `out/master.csv` | Interactive web page | `make visualize` | After data updates | `visualize_grants_web.py` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
 # AGENTS.md — Asia’s Automation Crew
 
-This file describes the automation agents, their goals, inputs, outputs, and schedules.
+This file describes the automation agents, their goals, inputs, outputs, schedules, and source paths.
 
 ## Contributing
 
-- Update the table whenever a new agent is added or when an existing agent's goal, inputs, outputs, or schedule changes.
+- Update the table whenever a new agent is added or when an existing agent's goal, inputs, outputs, schedule, or source path changes.
 - Keep entries concise: use capitalized agent names, wrap file paths and commands in backticks, and limit each column to a single sentence.
 - Run `npm test` before committing to verify repository checks pass.
 
-| Agent | Goal | Inputs | Outputs | Schedule |
-|-------|------|--------|---------|----------|
-| GrantWrangler | Merge raw grant CSV files into a master dataset | `data/csvs/` | `out/master.csv` | Run `make wrangle` when new data arrives |
-| ProgramWatcher | Cloudflare worker for simple health checks | HTTP request to `/api/health` | JSON `{status:'ok', agent:'ProgramWatcher'}` | Always on |
-| ScoreWorker | Cloudflare worker that doubles a numeric value | POST to `/api/score` with `{value}` | JSON `{score}` | On demand |
-| Visualizer | Local web server to explore the master dataset | `out/master.csv` | Interactive web page | Run `make visualize` after data updates |
+| Agent | Goal | Inputs | Outputs | Schedule | Source |
+|-------|------|--------|---------|----------|--------|
+| GrantWrangler | Merge raw grant CSV files into a master dataset | `data/csvs/` | `out/master.csv` | Run `make wrangle` when new data arrives | Implemented in `wrangle_grants.py` |
+| ProgramWatcher | Cloudflare worker for simple health checks | HTTP request to `/api/health` | JSON `{status:'ok', agent:'ProgramWatcher'}` | Always on | Implemented in `workers/program_watcher_worker.js` |
+| ScoreWorker | Cloudflare worker that doubles a numeric value | POST to `/api/score` with `{value}` | JSON `{score}` | On demand | Implemented in `worker/src/worker.ts` |
+| Visualizer | Local web server to explore the master dataset | `out/master.csv` | Interactive web page | Run `make visualize` after data updates | Implemented in `visualize_grants_web.py` |


### PR DESCRIPTION
## Summary
- document where each agent's code lives
- include source paths for health check, scoring, and visualization agents

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b1bf1158833280c39cc19ea40039