### PR TITLE
Add Wrangler config for worker with D1 binding

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -84,10 +84,13 @@ export default {
         });
       }
       const columns = await getColumns(env.DB);
-      const { results } = await env.DB.prepare(
-        `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
-      ).all();
-      const rows = results.map((r) => columns.map((c) => r[c] ?? ""));
+      let rows = [];
+      if (columns.length > 0) {
+        const { results } = await env.DB.prepare(
+          `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
+        ).all();
+        rows = results.map((r) => columns.map((c) => r[c] ?? ""));
+      }
       return new Response(renderDashboardPage(columns, rows), {
         headers: { "content-type": "text/html; charset=UTF-8" },
       });
@@ -130,13 +133,16 @@ export default {
 
     if (url.pathname === "/data") {
       const columns = await getColumns(env.DB);
-      const { results } = await env.DB.prepare(
-        `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
-      ).all();
-      const body = [
-        columns.join(","),
-        ...results.map((r) => columns.map((c) => r[c] ?? "").join(",")),
-      ].join("\n");
+      let body = "";
+      if (columns.length > 0) {
+        const { results } = await env.DB.prepare(
+          `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
+        ).all();
+        body = [
+          columns.join(","),
+          ...results.map((r) => columns.map((c) => r[c] ?? "").join(",")),
+        ].join("\n");
+      }
       return new Response(body, {
         headers: { "content-type": "text/csv; charset=UTF-8" },
       });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+name = "grant-manager"
+main = "worker.js"
+compatibility_date = "2024-05-29"
+
+[vars]
+USER_HASHES = '{"admin":"713bfda78870bf9d1b261f565286f85e97ee614efe5f0faf7c34e7ca4f65baca","user":"05d49692b755f99c4504b510418efeeeebfd466892540f27acf9a31a326d6504"}'
+
+[[d1_databases]]
+binding = "DB"
+database_name = "EQORE_DB"
+database_id = "EQORE_DB"


### PR DESCRIPTION
## Summary
- Configure Cloudflare Worker by adding wrangler.toml
- Guard dashboard and data queries when the programs schema is empty to avoid D1 errors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx wrangler dev --dry-run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/wrangler)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ab3789648332bdc84e1559c3230e