### PR TITLE
chore: add worker tooling deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,15 @@
     "doc": "docs",
     "example": "examples"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "wrangler": "^3.0.0",
+    "typescript": "^5.0.0",
+    "@cloudflare/workers-types": "^4.20250408.0"
+  },
   "scripts": {
-    "test": "pytest grant_summarizer"
+    "test": "pytest grant_summarizer",
+    "dev": "wrangler dev --local",
+    "deploy": "wrangler deploy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add Cloudflare worker tooling like wrangler and typescript to package.json
- expose dev/deploy npm scripts for running the worker

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@cloudflare%2fworkers-types)
- `npm test` (fails: IndentationError in grant_summarizer/extract.py)


------
https://chatgpt.com/codex/tasks/task_e_68b7bb72d12483329e802a35a5cdcc32