### PR TITLE
Fix wrangle_grants main indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "python -m unittest discover -s tests"
   },
   "repository": {
     "type": "git",

--- a/tests/test_wrangle_grants.py
+++ b/tests/test_wrangle_grants.py
@@ -1,0 +1,46 @@
+import tempfile
+from pathlib import Path
+import unittest
+import pandas as pd
+
+from wrangle_grants import load_folder, main
+
+
+class LoadFolderTests(unittest.TestCase):
+    def test_skip_empty_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            # Non-empty CSV
+            pd.DataFrame({'a': [1]}).to_csv(tmp_path / 'non_empty.csv', index=False)
+            # Empty CSV
+            pd.DataFrame({'a': []}).to_csv(tmp_path / 'empty.csv', index=False)
+
+            frames = load_folder(tmp_path)
+            self.assertEqual(len(frames), 1)
+            self.assertIn('_source_file', frames[0].columns)
+            self.assertTrue(frames[0]['_source_file'].iloc[0].endswith('non_empty.csv'))
+
+
+class MainTests(unittest.TestCase):
+    def test_main_writes_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            in_dir = tmp_path / 'in'
+            in_dir.mkdir()
+            pd.DataFrame({
+                'Grant name': ['Test Grant'],
+                'Sponsor org': ['Org'],
+                'Link': ['http://example.com'],
+                'Deadline': ['2030-01-01']
+            }).to_csv(in_dir / 'g.csv', index=False)
+            out_file = tmp_path / 'out.csv'
+
+            main(['--input', str(in_dir), '--out', str(out_file)])
+
+            self.assertTrue(out_file.exists())
+            df = pd.read_csv(out_file)
+            self.assertEqual(len(df), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wrangle_grants.py
+++ b/wrangle_grants.py
@@ -310,8 +310,6 @@ def load_folder(folder: Path) -> List[pd.DataFrame]:
             rows = len(df) if df is not None else 0
             logger.info("Loaded %s (%d rows)", p, rows)
             if df is not None and rows:
-            if len(df):
- main
                 df["_source_file"] = str(p)
                 frames.append(df)
     return frames
@@ -324,9 +322,7 @@ def ensure_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df[CANON_COLS + [c for c in df.columns if c not in CANON_COLS]]
 
 
-def 
-
-(argv=None):
+def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument(
         "--input",


### PR DESCRIPTION
## Summary
- fix indentation in `load_folder`
- restore `main` function definition
- add unit tests for `load_folder` and CLI entry
- configure npm test to run Python unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b05bca6c8332bf5825e8153becc3