### PR TITLE
Ensure programs table exists before queries

### DIFF
--- a/grant_summarizer/grant_summarizer/extract.py
+++ b/grant_summarizer/grant_summarizer/extract.py
@@ -59,18 +59,13 @@ def extract_text_from_link(link: str) -> str:
         data = resp.read()
         content_type = resp.headers.get("content-type", "")
         charset = resp.headers.get_content_charset("utf-8")
-
-    with urlopen(link) as resp:
-        data = resp.read()
-        content_type = resp.headers.get("content-type", "")
     if "pdf" in content_type or link.lower().endswith(".pdf"):
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
             tmp.write(data)
             tmp.flush()
             return extract_text(tmp.name)
-    else:
-        text = data.decode(charset, errors="ignore")
-        return _html_to_text(text)
+    text = data.decode(charset, errors="ignore")
+    return _html_to_text(text)
 
 
 def find_field_windows(text: str) -> Dict[str, str]:

--- a/grant_summarizer/grant_summarizer/extract.py
+++ b/grant_summarizer/grant_summarizer/extract.py
@@ -63,7 +63,6 @@ def extract_text_from_link(link: str) -> str:
     with urlopen(link) as resp:
         data = resp.read()
         content_type = resp.headers.get("content-type", "")
- main
     if "pdf" in content_type or link.lower().endswith(".pdf"):
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
             tmp.write(data)
@@ -71,7 +70,6 @@ def extract_text_from_link(link: str) -> str:
             return extract_text(tmp.name)
     else:
         text = data.decode(charset, errors="ignore")
-main
         return _html_to_text(text)
 
 

--- a/worker.js
+++ b/worker.js
@@ -43,6 +43,9 @@ export default {
     const cookie = request.headers.get("Cookie") || "";
     const loggedIn = cookie.includes("session=active");
     const users = env.USER_HASHES ? JSON.parse(env.USER_HASHES) : {};
+    await env.DB.exec(
+      "CREATE TABLE IF NOT EXISTS programs (id INTEGER PRIMARY KEY)"
+    );
 
     if (url.pathname === "/login" && request.method === "POST") {
       const form = await request.formData();
@@ -91,13 +94,6 @@ export default {
         ).all();
         rows = results.map((r) => columns.map((c) => r[c] ?? ""));
       }
-      const columnSql = columns.length
-        ? columns.map((c) => `"${c}"`).join(",")
-        : "*";
-      const { results } = await env.DB.prepare(
-        `SELECT ${columnSql} FROM programs`
-      ).all();
- main
       return new Response(renderDashboardPage(columns, rows), {
         headers: { "content-type": "text/html; charset=UTF-8" },
       });
@@ -150,18 +146,10 @@ export default {
           ...results.map((r) => columns.map((c) => r[c] ?? "").join(",")),
         ].join("\n");
       }
-      const columnSql = columns.length
-        ? columns.map((c) => `"${c}"`).join(",")
-        : "*";
-      const { results } = await env.DB.prepare(
-        `SELECT ${columnSql} FROM programs`
-      ).all();
-      
- main
-      return new Response(body, {
-        headers: { "content-type": "text/csv; charset=UTF-8" },
-      });
-    }
+        return new Response(body, {
+          headers: { "content-type": "text/csv; charset=UTF-8" },
+        });
+      }
 
     if (url.pathname === "/logout") {
       return new Response("", {

--- a/worker.js
+++ b/worker.js
@@ -18,6 +18,10 @@ async function getColumns(db) {
   return results.map((r) => r.name);
 }
 
+async function ensureProgramsTable(db) {
+  await db.exec("CREATE TABLE IF NOT EXISTS programs (id INTEGER PRIMARY KEY)");
+}
+
 async function newSchemaPage(db) {
   const columns = await getColumns(db);
   const inputs = columns
@@ -43,9 +47,7 @@ export default {
     const cookie = request.headers.get("Cookie") || "";
     const loggedIn = cookie.includes("session=active");
     const users = env.USER_HASHES ? JSON.parse(env.USER_HASHES) : {};
-    await env.DB.exec(
-      "CREATE TABLE IF NOT EXISTS programs (id INTEGER PRIMARY KEY)"
-    );
+    await ensureProgramsTable(env.DB);
 
     if (url.pathname === "/login" && request.method === "POST") {
       const form = await request.formData();
@@ -146,10 +148,10 @@ export default {
           ...results.map((r) => columns.map((c) => r[c] ?? "").join(",")),
         ].join("\n");
       }
-        return new Response(body, {
-          headers: { "content-type": "text/csv; charset=UTF-8" },
-        });
-      }
+      return new Response(body, {
+        headers: { "content-type": "text/csv; charset=UTF-8" },
+      });
+    }
 
     if (url.pathname === "/logout") {
       return new Response("", {


### PR DESCRIPTION
## Summary
- Ensure `programs` table exists by creating it at request start in the worker
- Remove stray debug tokens from `extract.py` that broke tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb163a448332948314641b025afe