### PR TITLE
feat: add grants.gov search option

### DIFF
--- a/grant_summarizer/README.md
+++ b/grant_summarizer/README.md
@@ -1,6 +1,6 @@
 # grant_summarizer
 
-Small CLI that extracts key fields from a grant PDF and writes a clean row and Markdown summaries.
+Small CLI that extracts key fields from a grant PDF and writes a clean row and Markdown summaries. It can also query the grants.gov API for opportunities.
 
 ## Installation
 
@@ -17,6 +17,9 @@ grant-summarizer --pdf path/to/file.pdf --format all --outdir ./dist
 
 # Or summarize directly from a URL (HTML or PDF)
 grant-summarizer --url https://example.com/grant.html --format all --outdir ./dist
+
+# Search grants.gov for opportunities
+grant-summarizer --search water --outdir ./dist
 ```
 
-This produces `clean_row.json`, `clean_row.csv`, and Markdown summary files in the output directory.
+This produces `clean_row.json`, `clean_row.csv`, and Markdown summary files in the output directory. When using `--search`, the API results are saved to `search_results.json`.

--- a/grant_summarizer/grant_summarizer/cli.py
+++ b/grant_summarizer/grant_summarizer/cli.py
@@ -5,26 +5,34 @@ from .extract import extract_text, extract_text_from_link, find_field_windows
 from .normalize import normalize_fields
 from .summarize import brief_bullets, one_pager_md, slide_bullets
 from .utils import write_json, write_csv
+from .grants_api import search_grants
 
 
 def main(
     pdf: str = typer.Option(None, help="Path to a grant PDF"),
     url: str = typer.Option(None, help="URL pointing to a grant page or PDF"),
     output_format: str = typer.Option("all", "--format", help="Output format: json, csv, md, or all"),
-    format: str = "all",
-  main
     outdir: str = "./dist",
     debug: bool = False,
+    search: str = typer.Option(None, help="Keyword to search on grants.gov"),
 ) -> None:
     """CLI entry point for the grant summarizer."""
-    if not pdf and not url:
-        raise typer.BadParameter("Either --pdf or --url must be provided")
-    if pdf and url:
-        raise typer.BadParameter("Use only one of --pdf or --url")
-    if debug:
-        typer.echo("Debug mode enabled")
+    provided = [arg for arg in (pdf, url, search) if arg]
+    if not provided:
+        raise typer.BadParameter("Provide --pdf, --url, or --search")
+    if len(provided) > 1:
+        raise typer.BadParameter("Use only one of --pdf, --url, or --search")
+
     out = Path(outdir)
     out.mkdir(parents=True, exist_ok=True)
+
+    if search:
+        results = search_grants(search)
+        write_json(results, out / "search_results.json")
+        return
+
+    if debug:
+        typer.echo("Debug mode enabled")
 
     if url:
         text = extract_text_from_link(url)

--- a/grant_summarizer/grant_summarizer/grants_api.py
+++ b/grant_summarizer/grant_summarizer/grants_api.py
@@ -1,0 +1,14 @@
+from typing import List, Dict
+import json
+from urllib.request import urlopen
+from urllib.parse import urlencode
+
+API_URL = "https://www.grants.gov/grantsws/rest/opportunities/search"
+
+
+def search_grants(keyword: str, limit: int = 10) -> List[Dict]:
+    """Search the grants.gov API for opportunities matching ``keyword``."""
+    params = urlencode({"keyword": keyword, "limit": limit})
+    with urlopen(f"{API_URL}?{params}", timeout=10) as resp:
+        data = json.load(resp)
+    return data.get("opportunities", [])

--- a/grant_summarizer/tests/test_grants_api.py
+++ b/grant_summarizer/tests/test_grants_api.py
@@ -1,0 +1,14 @@
+from io import BytesIO
+from unittest.mock import patch
+import json
+
+from grant_summarizer.grants_api import search_grants
+
+
+def test_search_grants():
+    fake_json = {"opportunities": [{"id": 1, "title": "Test"}]}
+    fake_bytes = json.dumps(fake_json).encode("utf-8")
+    with patch("grant_summarizer.grants_api.urlopen", return_value=BytesIO(fake_bytes)) as mock_urlopen:
+        results = search_grants("water", limit=1)
+    assert results == fake_json["opportunities"]
+    mock_urlopen.assert_called_once()


### PR DESCRIPTION
## Summary
- add `search_grants` helper using grants.gov API
- expose `--search` flag in CLI to save API results
- document search usage and cover it with tests

## Testing
- `npm test`
- `pip install requests` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dba1560c8332abe02ea08a8d5276