### PR TITLE
feat: schedule grants api search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,5 +13,6 @@ This file describes the automation agents, their goals, inputs, outputs, run com
 | GrantWrangler | Merge raw grant CSV files into a master dataset | `data/csvs/` | `out/master.csv` | `make wrangle` | On new data arrival | `wrangle_grants.py` |
 | ProgramWatcher | Cloudflare worker for simple health checks | HTTP request to `/api/health` | JSON `{status:'ok', agent:'ProgramWatcher'}` | `npx wrangler dev --local` | Always on | `workers/program_watcher_worker.js` |
 | ScoreWorker | Cloudflare worker that doubles a numeric value | POST to `/api/score` with `{value}` | JSON `{score}` | `npx wrangler dev --local` | On demand | `worker/src/worker.ts` |
+| GrantSearcher | Fetch grants.gov results on a schedule | Cron trigger | `scheduled-search.json` in R2 | `npx wrangler deploy` | Daily at 00:00 | `worker/src/worker.ts` |
 | GrantScorer | Serve scored grants for logged-in users | `USER_PROFILES` KV and D1 `programs` table | JSON array of scored grants | `npx wrangler dev --local` | On demand | `worker.js` |
 | Visualizer | Local web server to explore the master dataset | `out/master.csv` | Interactive web page | `make visualize` | After data updates | `visualize_grants_web.py` |

--- a/grant_summarizer/README.md
+++ b/grant_summarizer/README.md
@@ -1,6 +1,6 @@
 # grant_summarizer
 
-Small CLI that extracts key fields from a grant PDF and writes a clean row and Markdown summaries.
+Small CLI that extracts key fields from a grant PDF and writes a clean row and Markdown summaries. It can also query the grants.gov API for opportunities.
 
 ## Installation
 
@@ -17,6 +17,9 @@ grant-summarizer --pdf path/to/file.pdf --format all --outdir ./dist
 
 # Or summarize directly from a URL (HTML or PDF)
 grant-summarizer --url https://example.com/grant.html --format all --outdir ./dist
+
+# Search grants.gov for opportunities
+grant-summarizer --search water --outdir ./dist
 ```
 
-This produces `clean_row.json`, `clean_row.csv`, and Markdown summary files in the output directory.
+This produces `clean_row.json`, `clean_row.csv`, and Markdown summary files in the output directory. When using `--search`, the API results are saved to `search_results.json`.

--- a/grant_summarizer/grant_summarizer/cli.py
+++ b/grant_summarizer/grant_summarizer/cli.py
@@ -5,26 +5,34 @@ from .extract import extract_text, extract_text_from_link, find_field_windows
 from .normalize import normalize_fields
 from .summarize import brief_bullets, one_pager_md, slide_bullets
 from .utils import write_json, write_csv
+from .grants_api import search_grants
 
 
 def main(
     pdf: str = typer.Option(None, help="Path to a grant PDF"),
     url: str = typer.Option(None, help="URL pointing to a grant page or PDF"),
     output_format: str = typer.Option("all", "--format", help="Output format: json, csv, md, or all"),
-    format: str = "all",
-  main
     outdir: str = "./dist",
     debug: bool = False,
+    search: str = typer.Option(None, help="Keyword to search on grants.gov"),
 ) -> None:
     """CLI entry point for the grant summarizer."""
-    if not pdf and not url:
-        raise typer.BadParameter("Either --pdf or --url must be provided")
-    if pdf and url:
-        raise typer.BadParameter("Use only one of --pdf or --url")
-    if debug:
-        typer.echo("Debug mode enabled")
+    provided = [arg for arg in (pdf, url, search) if arg]
+    if not provided:
+        raise typer.BadParameter("Provide --pdf, --url, or --search")
+    if len(provided) > 1:
+        raise typer.BadParameter("Use only one of --pdf, --url, or --search")
+
     out = Path(outdir)
     out.mkdir(parents=True, exist_ok=True)
+
+    if search:
+        results = search_grants(search)
+        write_json(results, out / "search_results.json")
+        return
+
+    if debug:
+        typer.echo("Debug mode enabled")
 
     if url:
         text = extract_text_from_link(url)

--- a/grant_summarizer/grant_summarizer/grants_api.py
+++ b/grant_summarizer/grant_summarizer/grants_api.py
@@ -1,0 +1,14 @@
+from typing import List, Dict
+import json
+from urllib.request import urlopen
+from urllib.parse import urlencode
+
+API_URL = "https://www.grants.gov/grantsws/rest/opportunities/search"
+
+
+def search_grants(keyword: str, limit: int = 10) -> List[Dict]:
+    """Search the grants.gov API for opportunities matching ``keyword``."""
+    params = urlencode({"keyword": keyword, "limit": limit})
+    with urlopen(f"{API_URL}?{params}", timeout=10) as resp:
+        data = json.load(resp)
+    return data.get("opportunities", [])

--- a/grant_summarizer/tests/test_grants_api.py
+++ b/grant_summarizer/tests/test_grants_api.py
@@ -1,0 +1,14 @@
+from io import BytesIO
+from unittest.mock import patch
+import json
+
+from grant_summarizer.grants_api import search_grants
+
+
+def test_search_grants():
+    fake_json = {"opportunities": [{"id": 1, "title": "Test"}]}
+    fake_bytes = json.dumps(fake_json).encode("utf-8")
+    with patch("grant_summarizer.grants_api.urlopen", return_value=BytesIO(fake_bytes)) as mock_urlopen:
+        results = search_grants("water", limit=1)
+    assert results == fake_json["opportunities"]
+    mock_urlopen.assert_called_once()

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -94,5 +94,13 @@ export default {
     }
 
     return new Response('Not found', { status: 404, headers: corsHeaders });
+  },
+
+  async scheduled(event: any, env: Env): Promise<void> {
+    const api = 'https://www.grants.gov/api/common/search2';
+    const url = `${api}?keyword=water&limit=10`;
+    const res = await fetch(url);
+    const text = await res.text();
+    await env.PDF_BUCKET.put('scheduled-search.json', text);
   }
 };

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,6 +4,9 @@ name = "grant-demo"
 main = "src/worker.ts"
 compatibility_date = "2024-05-29"
 
+[triggers]
+crons = ["0 0 * * *"]
+
 [[d1_databases]]
 binding = "DB"
 database_name = "EQORE_DB"


### PR DESCRIPTION
## Summary
- add scheduled handler in worker to query grants.gov API and store results
- run worker daily via cron trigger
- document GrantSearcher agent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7dba1560c8332abe02ea08a8d5276