### PR TITLE
Add open-source AI chat endpoint

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -7,6 +7,9 @@
     "deploy": "wrangler deploy",
     "test": "echo \"No tests\""
   },
+  "dependencies": {
+    "@cloudflare/ai": "^1.0.0"
+  },
   "devDependencies": {
     "wrangler": "^3.0.0",
     "typescript": "^5.0.0"

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -1,5 +1,8 @@
+import { Ai } from '@cloudflare/ai';
+
 export interface Env {
   PDF_BUCKET: R2Bucket;
+  AI: Ai;
 }
 
 const corsHeaders = {
@@ -44,6 +47,33 @@ export default {
       }
       const score = value * 2;
       return new Response(JSON.stringify({ score }), {
+        headers: { ...corsHeaders, 'content-type': 'application/json' }
+      });
+    }
+
+    if (url.pathname === '/api/chat') {
+      if (request.method !== 'POST') {
+        return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+      }
+      let data: any;
+      try {
+        data = await request.json();
+      } catch {
+        return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'content-type': 'application/json' }
+        });
+      }
+      const prompt = data?.prompt;
+      if (typeof prompt !== 'string') {
+        return new Response(JSON.stringify({ error: '`prompt` must be a string' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'content-type': 'application/json' }
+        });
+      }
+      const ai = new Ai(env.AI);
+      const result = await ai.run('@cf/meta/llama-3-8b-instruct', { prompt });
+      return new Response(JSON.stringify(result), {
         headers: { ...corsHeaders, 'content-type': 'application/json' }
       });
     }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,6 +4,9 @@ name = "grant-demo"
 main = "src/worker.ts"
 compatibility_date = "2024-05-29"
 
+[[ai]]
+binding = "AI"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "EQORE_DB"


### PR DESCRIPTION
## Summary
- add /api/chat endpoint using Cloudflare Workers AI
- configure AI binding and dependency for open-source model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7e2a1a9648332a5581951061478a1