### PR TITLE
docs: add venv activation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ setup of the project:
    pip install -r requirements.txt
    ```
 
+   On Windows use `.venv\Scripts\activate` instead of `source .venv/bin/activate`.
+   Reactivate the environment in new shells with the same command.
+
 4. (Optional) Install Node dependencies for the Worker demo:
 
    ```bash
@@ -90,6 +93,9 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
+
+On Windows use `.venv\Scripts\activate` instead of `source .venv/bin/activate`.
+Run the activation command whenever you open a new terminal.
 
 ## Cloudflare Worker demo
 


### PR DESCRIPTION
## Summary
- document how to activate the Python virtual environment on Windows
- note to reactivate the environment for new shell sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ea86f9008332a93b6c0c417c7784