### PR TITLE
Fix queue consumer bindings

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -17,20 +17,12 @@ enabled = false
 
 [[r2_buckets]]
 binding = "PDF_BUCKET"
-bucket_name = "PDF_BUCKET"
-
-[[queues.consumers]]
-queue = "PDF_INGEST"
-script = "pdf-worker"
-
-[workers.pdf-worker]
-main = "src/pdf_worker.ts"
-
-
-
-[[r2_buckets]]
-binding = "PDF_BUCKET"
 bucket_name = "pdf-bucket"
 preview_bucket_name = "pdf-bucket"
 
+[[queues.consumers]]
+queue = "PDF_INGEST"
+service = "pdf-worker"
 
+[services.pdf-worker]
+main = "src/pdf_worker.ts"


### PR DESCRIPTION
## Summary
- fix Cloudflare worker configuration to use valid R2 bucket name and service-based queue consumer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ed8ce4a48332bb0f35e81a2b6857