### PR TITLE
Fix TypeScript environment for PDF worker

### DIFF
--- a/worker/src/pdf_worker.ts
+++ b/worker/src/pdf_worker.ts
@@ -32,7 +32,7 @@ export default {
         if (!resp.ok) {
           throw new Error(`summarizer status ${resp.status}`);
         }
-        const { csv, markdown } = await resp.json();
+        const { csv, markdown } = await resp.json<{ csv: string; markdown: string }>();
         const base = key.replace(/\.pdf$/i, '');
         await env.PDF_BUCKET.put(`${base}.csv`, csv);
         await env.PDF_BUCKET.put(`${base}.md`, markdown);

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types"],
+    "target": "es2021",
+    "lib": ["es2021"]
   }
 }


### PR DESCRIPTION
## Summary
- target ES2021 in worker TypeScript config so Promise is available
- type the summarizer JSON in pdf_worker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7f69b5858833296e03d40a7d90a90