### PR TITLE
Add open-source AI chat endpoint

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -7,6 +7,9 @@
     "deploy": "wrangler deploy",
     "test": "echo \"No tests\""
   },
+  "dependencies": {
+    "@cloudflare/ai": "^1.0.0"
+  },
   "devDependencies": {
     "wrangler": "^3.0.0",
     "typescript": "^5.0.0"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,6 +4,12 @@ name = "grant-demo"
 main = "src/worker.ts"
 compatibility_date = "2024-05-29"
 
+[vars]
+CHAT_API_KEY = ""
+
+[[ai]]
+binding = "AI"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "EQORE_DB"


### PR DESCRIPTION
## Summary
- add /api/chat endpoint using Cloudflare Workers AI
- configure AI binding and dependency for open-source model
- protect /api/chat with API token and expose Authorization header

## Testing
- `npm test` *(fails: pytest not found after unsuccessful dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e2a1a9648332a5581951061478a1