### PR TITLE
Fix login redirect loop and show user profile on dashboard

### DIFF
--- a/templates/dashboard.js
+++ b/templates/dashboard.js
@@ -1,13 +1,26 @@
-export function renderDashboardPage(headers = [], rows = []) {
+export function renderDashboardPage(
+  headers = [],
+  rows = [],
+  username = "",
+  profile = {}
+) {
   const headerRow = headers.map((h) => `<th>${h}</th>`).join("");
   const bodyRows = rows
     .map((cols) => `<tr>${cols.map((c) => `<td>${c}</td>`).join("")}</tr>`)
     .join("");
+  const profileEntries = Object.entries(profile)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join(", ");
+  const profileHtml = profileEntries
+    ? `<p>Your profile settings: ${profileEntries}</p>`
+    : "<p>No custom profile settings.</p>";
   return `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"><title>Dashboard</title></head>
 <body>
   <h1>Program Data Schema</h1>
+  <p>Logged in as <strong>${username}</strong></p>
+  ${profileHtml}
   <table border="1">
     <thead><tr>${headerRow}</tr></thead>
     <tbody>${bodyRows}</tbody>


### PR DESCRIPTION
## Summary
- Avoid login redirect loops by omitting the Secure attribute on session cookies when using HTTP.
- Show the current user's profile weights and username on the dashboard, ensuring a clear indication of login state.
- Redirect root path to dashboard when logged in and set logout cookies accordingly.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8021d98648332951a8a0e1eb932b2