### PR TITLE
Add login gate to visualization app

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ app:
 ```bash
 python visualize_grants_web.py
 ```
-
+It opens with a minimal login form (`client` / `demo`) before showing the data.
 The page includes a dataset selector letting you switch between
 `out/master.csv` (default) and `data/programs.csv`. If the chosen CSV is
 missing, the app falls back to tiny sample data so the visualization can still


### PR DESCRIPTION
## Summary
- add simple session-based login to visualization Flask app
- protect index and scoring pages with authentication and add logout
- document default credentials for visualizer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b805f025c8833294a3a44dc1212452