### PR TITLE
Add packaging and deployment tooling

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,6 @@
+FROM node:20
+WORKDIR /app
+COPY package.json package-lock.json cli.js ./
+RUN npm ci
+COPY . .
+CMD ["grant-manager", "worker"]

--- a/Dockerfile.wrangler
+++ b/Dockerfile.wrangler
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml README.md requirements.txt ./
+RUN pip install --no-cache-dir .
+COPY . .
+CMD ["wrangle-grants", "--input", "data/csvs", "--out", "out/master.csv"]

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+
+const args = process.argv.slice(2);
+
+if (args[0] === 'worker') {
+  const child = spawn('npx', ['wrangler', 'dev', '--local'], { stdio: 'inherit' });
+  child.on('exit', code => process.exit(code));
+} else {
+  console.log('Usage: grant-manager worker');
+}

--- a/docs/consulting_setup.md
+++ b/docs/consulting_setup.md
@@ -1,0 +1,28 @@
+# Consulting Deployment Setup
+
+This guide outlines how to deploy the grant manager components — data wrangler, web UI, and worker — using Docker and Docker Compose.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Git clone of the repository
+
+## Build and Run
+
+1. Build images and start the stack:
+   ```bash
+   cd examples
+   docker compose up --build
+   ```
+   The data wrangler will process CSV files in `data/` and write outputs to `out/`.
+
+2. Access the services:
+   - Web UI: [http://localhost:5000](http://localhost:5000)
+   - Worker (Wrangler dev server): [http://localhost:8787](http://localhost:8787)
+
+3. To rerun the wrangler after updating data, restart the `wrangler` service:
+   ```bash
+   docker compose run --rm wrangler
+   ```
+
+The Compose file mounts `../data` and `../out` so changes persist on the host.

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.9'
+services:
+  wrangler:
+    build:
+      context: ..
+      dockerfile: Dockerfile.wrangler
+    volumes:
+      - ../data:/app/data
+      - ../out:/app/out
+  web:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    ports:
+      - "5000:5000"
+    volumes:
+      - ../out:/app/out
+    depends_on:
+      - wrangler
+  worker:
+    build:
+      context: ..
+      dockerfile: Dockerfile.worker
+    ports:
+      - "8787:8787"
+    depends_on:
+      - wrangler

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/asiakay/grant-manager-tool-demo/issues"
   },
-  "homepage": "https://github.com/asiakay/grant-manager-tool-demo#readme"
+  "homepage": "https://github.com/asiakay/grant-manager-tool-demo#readme",
+  "bin": {
+    "grant-manager": "./cli.js"
+  }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "grant-manager-tool-demo"
+version = "0.1.0"
+description = "Utility tools for wrangling and visualizing grant data"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "pandas",
+    "openpyxl",
+    "flask",
+    "plotly",
+]
+
+[project.scripts]
+wrangle-grants = "wrangle_grants:main"
+search-grants = "search_grants:main"


### PR DESCRIPTION
## Summary
- add pyproject.toml for pip-based installs and Python CLI entry points
- expose `grant-manager` node CLI and supporting Dockerfiles for wrangler and worker
- provide compose example and consulting deployment docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b808a8687483328b058ccba5de6ad5