### PR TITLE
fix: update KV namespace binding to USER_PROFILES

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,7 +17,7 @@ database_id = "85970bbc-3d0b-4922-8ec2-3845f4606201"
 
 
 [[kv_namespaces]]
-binding = "grant-demo-USER_PROFILES"
+binding = "USER_PROFILES"
 id = "065f64c71e0747079a2e3d86b292770d"
 
 


### PR DESCRIPTION
## Summary
- rename KV namespace binding to USER_PROFILES for worker access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b81544e3d48332bc3c31d47845cdc7