### PR TITLE
Guard worker against missing USER_PROFILES binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ environment variable. After logging in, the `/dashboard` view renders the
 program data schema table, with links to `/schema` (JSON) and `/data` (CSV)
 for alternate views. Authenticated requests to `/api/grants` return the grant
 rows scored with weights from the user's profile stored in the `USER_PROFILES`
-KV namespace.
+KV namespace. If that binding is missing, the Worker logs a warning and falls
+back to an empty profile, and `/api/grants` responds with an explanatory error.
 
 The Worker relies on a D1 database. Run the migration before deploying:
 
@@ -120,7 +121,8 @@ wrangler d1 migrations apply EQORE_DB
 ```
 
 Store each user's weight profile as JSON in the `USER_PROFILES` KV namespace
-to control how grants are scored.
+to control how grants are scored. If the binding isn't configured, scoring
+defaults to zero for all grants.
 
 ## Developer guide
 

--- a/worker.js
+++ b/worker.js
@@ -100,7 +100,12 @@ export default {
         rows = results.map((r) => columns.map((c) => r[c] ?? ""));
       }
       let profile = {};
-      const profileRaw = await env.USER_PROFILES.get(username);
+      let profileRaw = null;
+      if (env.USER_PROFILES) {
+        profileRaw = await env.USER_PROFILES.get(username);
+      } else {
+        console.warn("USER_PROFILES binding is not configured");
+      }
       if (profileRaw) {
         try {
           profile = JSON.parse(profileRaw);
@@ -169,7 +174,13 @@ export default {
       if (!loggedIn) {
         return new Response("Unauthorized", { status: 401 });
       }
-      const profileRaw = await env.USER_PROFILES.get(username);
+      let profileRaw = null;
+      if (env.USER_PROFILES) {
+        profileRaw = await env.USER_PROFILES.get(username);
+      } else {
+        console.warn("USER_PROFILES binding is not configured");
+        return new Response("USER_PROFILES binding not configured", { status: 500 });
+      }
       let profile = {};
       if (profileRaw) {
         try {


### PR DESCRIPTION
## Summary
- Avoid runtime errors by checking for missing `USER_PROFILES` before fetching user data
- Return an error from `/api/grants` when the binding is absent and log a warning
- Document the fallback behavior when the binding isn't configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8154a0d1483328d10055e7fe638ed