### PR TITLE
Simplify grant summarizer CLI parameters

### DIFF
--- a/grant_summarizer/grant_summarizer/cli.py
+++ b/grant_summarizer/grant_summarizer/cli.py
@@ -5,31 +5,26 @@ from .extract import extract_text, extract_text_from_link, find_field_windows
 from .normalize import normalize_fields
 from .summarize import brief_bullets, one_pager_md, slide_bullets
 from .utils import write_json, write_csv
-from .grants_api import search_grants
 
 
 def main(
     pdf: str = typer.Option(None, help="Path to a grant PDF"),
     url: str = typer.Option(None, help="URL pointing to a grant page or PDF"),
-    output_format: str = typer.Option("all", "--format", help="Output format: json, csv, md, or all"),
+    output_format: str = typer.Option(
+        "all", "--format", help="Output format: json, csv, md, or all"
+    ),
     outdir: str = "./dist",
     debug: bool = False,
-    search: str = typer.Option(None, help="Keyword to search on grants.gov"),
 ) -> None:
     """CLI entry point for the grant summarizer."""
-    provided = [arg for arg in (pdf, url, search) if arg]
+    provided = [arg for arg in (pdf, url) if arg]
     if not provided:
-        raise typer.BadParameter("Provide --pdf, --url, or --search")
+        raise typer.BadParameter("Provide --pdf or --url")
     if len(provided) > 1:
-        raise typer.BadParameter("Use only one of --pdf, --url, or --search")
+        raise typer.BadParameter("Use only one of --pdf or --url")
 
     out = Path(outdir)
     out.mkdir(parents=True, exist_ok=True)
-
-    if search:
-        results = search_grants(search)
-        write_json(results, out / "search_results.json")
-        return
 
     if debug:
         typer.echo("Debug mode enabled")


### PR DESCRIPTION
## Summary
- streamline CLI `main` signature to only accept PDF or URL inputs and remove unused search functionality
- retain `typer.run(main)` entrypoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81a9e432c8332aafc8a329ce71b7a