### PR TITLE
feat: add debug logging for CLI

### DIFF
--- a/grant_summarizer/grant_summarizer/cli.py
+++ b/grant_summarizer/grant_summarizer/cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging
 import typer
 
 from .extract import extract_text, extract_text_from_link, find_field_windows
@@ -6,6 +7,10 @@ from .normalize import normalize_fields
 from .summarize import brief_bullets, one_pager_md, slide_bullets
 from .utils import write_json, write_csv
 from .grants_api import search_grants
+
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 def main(
@@ -26,31 +31,57 @@ def main(
     out = Path(outdir)
     out.mkdir(parents=True, exist_ok=True)
 
-    if search:
-        results = search_grants(search)
-        write_json(results, out / "search_results.json")
-        return
-
+    handler = None
     if debug:
         typer.echo("Debug mode enabled")
+        log_file = out / "run.log"
+        handler = logging.FileHandler(log_file)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
 
-    if url:
-        text = extract_text_from_link(url)
-    else:
-        text = extract_text(pdf)
-    windows = find_field_windows(text)
-    row = normalize_fields(windows)
+    try:
+        logger.info("Starting processing")
 
-    if output_format in ("json", "all"):
-        write_json(row, out / "clean_row.json")
-    if output_format in ("csv", "all"):
-        write_csv(row, out / "clean_row.csv")
-    if output_format in ("md", "all"):
-        (out / "brief.md").write_text("\n".join(f"- {b}" for b in brief_bullets(row)) + "\n")
-        (out / "one_pager.md").write_text(one_pager_md(row))
-        (out / "slide_bullets.md").write_text(
-            "\n".join(f"- {b}" for b in slide_bullets(row)) + "\n"
-        )
+        if search:
+            logger.info("Search term: %s", search)
+            results = search_grants(search)
+            path = out / "search_results.json"
+            write_json(results, path)
+            logger.info("Wrote %s", path)
+            return
+
+        if url:
+            logger.info("Source URL: %s", url)
+            text = extract_text_from_link(url)
+        else:
+            logger.info("Source PDF: %s", pdf)
+            text = extract_text(pdf)
+        windows = find_field_windows(text)
+        row = normalize_fields(windows)
+
+        if output_format in ("json", "all"):
+            path = out / "clean_row.json"
+            write_json(row, path)
+            logger.info("Wrote %s", path)
+        if output_format in ("csv", "all"):
+            path = out / "clean_row.csv"
+            write_csv(row, path)
+            logger.info("Wrote %s", path)
+        if output_format in ("md", "all"):
+            path = out / "brief.md"
+            path.write_text("\n".join(f"- {b}" for b in brief_bullets(row)) + "\n")
+            logger.info("Wrote %s", path)
+            path = out / "one_pager.md"
+            path.write_text(one_pager_md(row))
+            logger.info("Wrote %s", path)
+            path = out / "slide_bullets.md"
+            path.write_text("\n".join(f"- {b}" for b in slide_bullets(row)) + "\n")
+            logger.info("Wrote %s", path)
+    finally:
+        if handler:
+            logger.removeHandler(handler)
+            handler.close()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/grant_summarizer/tests/test_cli.py
+++ b/grant_summarizer/tests/test_cli.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from grant_summarizer.cli import main
+
+
+def test_run_log_created(tmp_path):
+    html_file = tmp_path / "sample.html"
+    html_file.write_text(
+        "Grant opportunity funding up to $5M with applications due Jan 1, 2025"
+    )
+
+    outdir = tmp_path / "out"
+    main(
+        pdf=None,
+        url=html_file.as_uri(),
+        output_format="json",
+        outdir=str(outdir),
+        debug=True,
+        search=None,
+    )
+
+    log_file = outdir / "run.log"
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "Starting processing" in content
+    assert "Source URL" in content
+    assert "clean_row.json" in content


### PR DESCRIPTION
## Summary
- log run events to a file when debug mode is enabled
- record source URL or PDF and each output file
- test debug logging creates run.log with expected entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81b51269083328c82fabe9f515fc2