### PR TITLE
Generate templated grant narratives

### DIFF
--- a/grant_summarizer/grant_summarizer/cli.py
+++ b/grant_summarizer/grant_summarizer/cli.py
@@ -6,6 +6,7 @@ from .extract import extract_text, extract_text_from_link, find_field_windows
 from .normalize import normalize_fields
 from .summarize import brief_bullets, one_pager_md, slide_bullets
 from .utils import write_json, write_csv
+from .grants_api import search_grants
 
 
 logger = logging.getLogger(__name__)
@@ -24,8 +25,6 @@ def main(
         False, help="Allow downloading remote URLs (insecure)"
     ),
     search: str = typer.Option(None, help="Keyword to search on grants.gov"),
-  
- main
 ) -> None:
     """CLI entry point for the grant summarizer."""
     provided = [arg for arg in (pdf, url) if arg]
@@ -37,7 +36,7 @@ def main(
     out = Path(outdir)
     out.mkdir(parents=True, exist_ok=True)
 
-main
+    handler: logging.FileHandler | None = None
     if debug:
         typer.echo("Debug mode enabled")
         log_file = out / "run.log"

--- a/grant_summarizer/grant_summarizer/summarize.py
+++ b/grant_summarizer/grant_summarizer/summarize.py
@@ -14,22 +14,120 @@ def brief_bullets(row: CleanRow) -> list[str]:
 
 
 def one_pager_md(row: CleanRow) -> str:
-    """Return ~250+ word markdown narrative for the grant."""
-    sections = [
-        f"# {row.grant_name}\n",
-        f"**Sponsor:** {row.sponsor_org}\n",
-        f"**Funding:** {row.award_max}\n",
-        f"**Deadline:** {row.app_deadline}\n",
-        f"**Industries:** {row.industries}\n",
-        f"**Match:** {row.match_req_pct}\n",
-        f"{row.extra_notes}\n",
-    ]
-    text = "\n".join(sections)
-    words = text.split()
-    if len(words) < 260:
-        filler = ["lorem"] * (260 - len(words))
-        text += " \n" + " ".join(filler)
-    return text
+    """Return ~250–400 word markdown narrative for the grant."""
+
+    sections: list[str] = [f"# {row.grant_name}", f"**Sponsor:** {row.sponsor_org}"]
+
+    def add(title: str, body: str) -> None:
+        sections.append(f"## {title}\n{body}")
+
+    if row.award_max or row.match_req_pct:
+        parts: list[str] = []
+        if row.award_max:
+            parts.append(
+                f"As funding up to {row.award_max} is available, applicants can design "
+                "ambitious projects that address pressing community or industry needs."
+            )
+        else:
+            parts.append(
+                "The program offers financial support for ambitious projects that address "
+                "pressing community or industry needs."
+            )
+        if row.match_req_pct:
+            parts.append(
+                f"A match of {row.match_req_pct} demonstrates commitment, and proposals "
+                "should justify the requested amount with clear outcomes."
+            )
+        parts.append(
+            "Budgets should illustrate responsible spending and long-term impact. "
+            "Reviewers appreciate plans that leverage diverse revenue sources and "
+            "minimize risk."
+        )
+        add("Funding", " ".join(parts))
+
+    if row.app_deadline:
+        add(
+            "Deadline",
+            (
+                f"Applications are due by {row.app_deadline}, and late submissions are "
+                "typically not accepted. Prospective applicants should establish internal "
+                "timelines for drafting, review, and authorization to ensure all materials "
+                "are uploaded before the cutoff. Early preparation reduces last-minute "
+                "errors and allows time for addressing technical issues. Maintaining a "
+                "checklist of required attachments helps teams stay organized."
+            ),
+        )
+
+    if row.timeline_summary:
+        add(
+            "Period",
+            (
+                f"The anticipated period of performance spans {row.timeline_summary}, "
+                "providing ample opportunity for project execution and evaluation. "
+                "Applicants should schedule milestones that demonstrate steady progress "
+                "and integrate planning time where necessary. Clear timelines help "
+                "funders assess feasibility and ensure resources are deployed efficiently "
+                "throughout the award. Regular reviews keep projects aligned with "
+                "strategic objectives."
+            ),
+        )
+
+    if row.partners_notes:
+        add(
+            "Eligibility",
+            (
+                f"Eligibility typically includes {row.partners_notes}. Organizations must "
+                "verify their legal status and capacity to manage federal funds. "
+                "Demonstrated experience with similar initiatives strengthens applications, "
+                "and partnerships can broaden impact. Applicants should consult the "
+                "solicitation for complete eligibility details and confirm there are no "
+                "statutory exclusions. Early engagement with potential partners can clarify "
+                "roles and responsibilities."
+            ),
+        )
+
+    if row.industries:
+        add(
+            "Industries",
+            (
+                f"Target industries for this opportunity include {row.industries}. "
+                "Proposals should articulate the specific market gaps the project addresses "
+                "and how industry stakeholders will benefit. Aligning activities with "
+                "sector priorities strengthens the case for funding and demonstrates "
+                "awareness of broader economic trends influencing the field. Collaboration "
+                "with trade groups or consortia can further amplify outcomes."
+            ),
+        )
+
+    if row.reimb_pct:
+        add(
+            "Reimbursement",
+            (
+                f"Costs are reimbursed at a rate of {row.reimb_pct}, meaning organizations "
+                "front expenses and request repayment. Applicants should maintain "
+                "meticulous financial records and use approved accounting systems to "
+                "document costs. Prompt invoicing accelerates cash flow, and understanding "
+                "allowability rules prevents disallowed charges that could impact budgets. "
+                "Clear communication with the grant officer helps resolve questions "
+                "quickly."
+            ),
+        )
+
+    if row.reporting_schema:
+        add(
+            "Reporting",
+            (
+                f"Reporting requirements follow a {row.reporting_schema} schedule. Awardees "
+                "must submit timely updates that summarize activities, expenditures, and "
+                "measurable outcomes. Good reporting demonstrates accountability and "
+                "informs future policy decisions. Establishing internal review processes and "
+                "assigning responsibility for data collection will make compliance smoother "
+                "and ensure narratives remain consistent. Detailed records also support "
+                "sustainability planning beyond the grant period."
+            ),
+        )
+
+    return "\n\n".join(sections) + "\n"
 
 
 def slide_bullets(row: CleanRow) -> list[str]:

--- a/grant_summarizer/tests/test_summarize.py
+++ b/grant_summarizer/tests/test_summarize.py
@@ -8,9 +8,10 @@ def sample_row() -> CleanRow:
         sponsor_org="Org",
         award_max="$5M",
         app_deadline="Jan 1, 2025",
+        timeline_summary="45 months",
+        partners_notes="State agencies",
         industries="Tech",
         match_req_pct="0%",
-        timeline_summary="45 months",
         reimb_pct="80%",
         reporting_schema="Quarterly",
         extra_notes="Notes",
@@ -33,5 +34,14 @@ def test_one_pager_md():
     text = one_pager_md(sample_row())
     word_count = len(text.split())
     assert 250 <= word_count <= 400
-    assert "Funding" in text
-    assert "Deadline" in text
+    for heading in [
+        "Funding",
+        "Deadline",
+        "Period",
+        "Eligibility",
+        "Industries",
+        "Reimbursement",
+        "Reporting",
+    ]:
+        assert f"## {heading}" in text
+    assert "lorem" not in text


### PR DESCRIPTION
## Summary
- build one-pager markdown narratives from structured sections like Funding, Deadline, Eligibility and more
- expand unit tests to assert each section and valid word count
- fix CLI syntax and missing import uncovered by tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b81ef4e0a48332a11d8a40b0e16b38