### PR TITLE
Expose wrangler via Flask API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file describes the automation agents, their goals, inputs, outputs, run com
 | GrantScorer    | Serve scored grants for logged-in users         | `USER_PROFILES` KV and D1 `programs` table | JSON array of scored grants                  | `npx wrangler dev --local`          | On demand           | `worker.js`                         |
 | Visualizer     | Local web server to explore the master dataset  | `out/master.csv`                           | Interactive web page                         | `make visualize`                    | After data updates  | `visualize_grants_web.py`           |
 | GrantFinder    | Query Grants.gov with keywords and filters      | CLI args                                   | CSV/TSV file and printed summary             | `python search_grants.py education` | On demand           | `search_grants.py`                  |
+| WrangleAPI     | Serve wrangled grants via HTTP                  | `data/csvs/`                               | JSON master dataset                          | `python wrangle_api.py`             | On demand           | `wrangle_api.py` |
 
 # AGENTS.md (for `ui/` components)
 

--- a/examples/wrangle_api_client.html
+++ b/examples/wrangle_api_client.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Wrangle API Demo</title>
+</head>
+<body>
+  <button id="run">Run Wrangler</button>
+  <pre id="output"></pre>
+  <script>
+    document.getElementById('run').addEventListener('click', () => {
+      fetch('http://localhost:5000/api/wrangle')
+        .then(response => response.json())
+        .then(data => {
+          document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+        })
+        .catch(err => {
+          console.error('API error', err);
+        });
+    });
+  </script>
+</body>
+</html>

--- a/wrangle_api.py
+++ b/wrangle_api.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Expose ``wrangle_grants.py`` as a simple HTTP API."""
+
+from flask import Flask, jsonify
+import pandas as pd
+from pathlib import Path
+from wrangle_grants import main as wrangle_main
+
+app = Flask(__name__)
+
+
+@app.route("/api/wrangle", methods=["GET"])
+def api_wrangle() -> tuple:
+    """Run the grant wrangler and return the master dataset as JSON."""
+    try:
+        wrangle_main(["--input", "data/csvs", "--out", "out/master.csv"])
+    except SystemExit as exc:  # ``wrangle_grants`` uses ``SystemExit`` on error
+        return jsonify({"error": str(exc)}), 400
+
+    csv_path = Path("out/master.csv")
+    if not csv_path.exists():
+        return jsonify({"error": "wrangle output not found"}), 500
+
+    df = pd.read_csv(csv_path)
+    return jsonify(df.to_dict(orient="records"))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- expose `wrangle_grants.py` through a new Flask `/api/wrangle` endpoint
- add browser example that fetches wrangled data
- document WrangleAPI in `AGENTS.md`

## Testing
- `curl -s http://localhost:5000/api/wrangle | head`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8282f27fc833290b4948dcc73902c