### PR TITLE
docs: document migration and deployment order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,29 @@ This file describes the automation agents, their goals, inputs, outputs, run com
 - Keep entries concise: use capitalized agent names, wrap file paths and commands in backticks, and limit each column to a single sentence.
 - Run `npm test` before committing to verify repository checks pass.
 
+## Deployment Order
+
+Follow this sequence to set up the system end to end:
+
+1. **Apply D1 migrations**
+   ```bash
+   wrangler d1 migrations apply
+   ```
+2. **Deploy `/upload` endpoint**
+   ```bash
+   npm run build
+   wrangler deploy
+   ```
+3. **Run the extraction queue worker**
+   ```bash
+   wrangler queues consume PDF_INGEST src/pdf_worker.ts
+   ```
+4. **Scoring**
+   - Run your scoring pipeline after extraction completes.
+
+Run `npm test` before committing to verify repository checks pass.
+
+
 | Agent          | Goal                                            | Inputs                                     | Outputs                                      | Run Command                         | Schedule            | Source                              |
 | -------------- | ----------------------------------------------- | ------------------------------------------ | -------------------------------------------- | ----------------------------------- | ------------------- | ----------------------------------- |
 | GrantWrangler  | Merge raw grant CSV files into a master dataset | `data/csvs/`                               | `out/master.csv`                             | `make wrangle`                      | On new data arrival | `wrangle_grants.py`                 |


### PR DESCRIPTION
## Summary
- describe required order: apply D1 migrations, deploy `/upload` endpoint, start extraction queue worker, then scoring
- include explicit commands (`wrangler d1 migrations apply`, `npm run build`, `wrangler deploy`, queue consumer)
- remind contributors to run `npm test` before committing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ecd7c8588332bef362caec619de5