### PR TITLE
docs: document D1 schema and link contract in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file describes the automation agents, their goals, inputs, outputs, run com
 - Update the table whenever a new agent is added or when an existing agent's goal, inputs, outputs, run command, schedule, or source path changes.
 - Keep entries concise: use capitalized agent names, wrap file paths and commands in backticks, and limit each column to a single sentence.
 - Run `npm test` before committing to verify repository checks pass.
+- `docs/data_contract.json` is the canonical reference for the D1 table schema and field definitions. Update the contract and this file together whenever schemas or scoring rules change.
 
 | Agent          | Goal                                            | Inputs                                     | Outputs                                      | Run Command                         | Schedule            | Source                              |
 | -------------- | ----------------------------------------------- | ------------------------------------------ | -------------------------------------------- | ----------------------------------- | ------------------- | ----------------------------------- |

--- a/docs/data_contract.json
+++ b/docs/data_contract.json
@@ -1,0 +1,24 @@
+{
+  "table": "programs",
+  "description": "D1 table storing scored grant programs.",
+  "fields": [
+    {"name": "Type", "type": "TEXT", "description": "Program category"},
+    {"name": "Name", "type": "TEXT", "primary_key": true, "description": "Program name"},
+    {"name": "Sponsor", "type": "TEXT", "description": "Sponsoring organization"},
+    {"name": "Source URL", "type": "TEXT", "description": "Link to program details"},
+    {"name": "Region / Eligibility", "type": "TEXT", "description": "Eligible region or requirements"},
+    {"name": "Deadline / Next Cohort", "type": "TEXT", "description": "Application deadline or next cohort date"},
+    {"name": "Cadence", "type": "TEXT", "description": "Program frequency"},
+    {"name": "Benefits", "type": "TEXT", "description": "Benefits offered"},
+    {"name": "Eligibility (key conditions)", "type": "TEXT", "description": "Key eligibility criteria"},
+    {"name": "Stage", "type": "TEXT", "description": "Target startup stage"},
+    {"name": "Non-dilutive?", "type": "TEXT", "description": "Whether funding is non-dilutive"},
+    {"name": "Stack Required?", "type": "TEXT", "description": "Whether sponsor stack is required"},
+    {"name": "Relevance", "type": "TEXT", "description": "Relevance score"},
+    {"name": "Fit", "type": "TEXT", "description": "Fit score"},
+    {"name": "Ease", "type": "TEXT", "description": "Ease score"},
+    {"name": "Weighted Score", "type": "TEXT", "description": "Combined weighted score"},
+    {"name": "Notes / Actions", "type": "TEXT", "description": "Notes or next actions"}
+  ],
+  "scoring_rules": "Relevance, Fit, and Ease are scored 0-3 and aggregated into Weighted Score. Update this contract when schemas or scoring rules change."
+}


### PR DESCRIPTION
## Summary
- Reference docs/data_contract.json as canonical D1 schema in AGENTS.md
- Define programs table schema and scoring rules in docs/data_contract.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ece319a48332aae6bcefcedd3eeb