### PR TITLE
docs: add worker agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ This file describes the automation agents, their goals, inputs, outputs, run com
 | Visualizer     | Local web server to explore the master dataset  | `out/master.csv`                           | Interactive web page                         | `make visualize`                    | After data updates  | `visualize_grants_web.py`           |
 | GrantFinder    | Query Grants.gov with keywords and filters      | CLI args                                   | CSV/TSV file and printed summary             | `python search_grants.py education` | On demand           | `search_grants.py`                  |
 | WrangleAPI     | Serve wrangled grants via HTTP                  | `data/csvs/`                               | JSON master dataset                          | `python wrangle_api.py`             | On demand           | `wrangle_api.py` |
+| UploadWorker   | Store uploaded PDFs in R2 for downstream extraction | POST to `/upload` with file or `{name,data}` | PDF object in `PDF_BUCKET`                   | `npx wrangler dev --local`          | On demand           | `worker/src/worker.ts` |
+| ExtractionWorker | Convert PDFs to summaries via grant_summarizer | Queue message `{key}` from `PDF_INGEST`    | CSV and Markdown files in `PDF_BUCKET`       | `npx wrangler dev src/pdf_worker.ts --local` | On `PDF_INGEST` message | `worker/src/pdf_worker.ts` |
+| ScoringWorker  | Score extracted rows and persist results        | Queue message `{file}` from `SCORE_QUEUE`  | Scored CSV in `PDF_BUCKET`                   | `npx wrangler dev src/score_worker.ts --local` | On `SCORE_QUEUE` message | `worker/src/score_worker.ts` |
 
 # AGENTS.md (for `ui/` components)
 


### PR DESCRIPTION
## Summary
- document UploadWorker for handling PDF uploads
- add ExtractionWorker that converts queued PDFs to summaries
- note ScoringWorker to score summarized rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ecec14988332b04649ae41a7e6dc