### PR TITLE
Add test endpoints page for logged-in users

### DIFF
--- a/templates/dashboard.js
+++ b/templates/dashboard.js
@@ -28,6 +28,7 @@ export function renderDashboardPage(
   <p>
     <a href="/schema">View schema JSON</a> |
     <a href="/data">Sample CSV</a> |
+    <a href="/test-endpoints">Test Endpoints</a> |
     <a href="/logout">Logout</a>
   </p>
 </body>

--- a/templates/test_endpoints.js
+++ b/templates/test_endpoints.js
@@ -1,0 +1,25 @@
+export function renderTestEndpointsPage(username = "") {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Test Endpoints</title></head>
+<body>
+  <h1>Endpoint Tester</h1>
+  <p>Logged in as <strong>${username}</strong></p>
+  <button id="loadGrants">Load Grants</button>
+  <pre id="output"></pre>
+  <p><a href="/dashboard">Back to dashboard</a></p>
+  <script>
+    document.getElementById('loadGrants').addEventListener('click', async () => {
+      const res = await fetch('/api/grants');
+      const text = await res.text();
+      try {
+        const data = JSON.parse(text);
+        document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+      } catch (e) {
+        document.getElementById('output').textContent = text;
+      }
+    });
+  </script>
+</body>
+</html>`;
+}

--- a/worker.js
+++ b/worker.js
@@ -1,5 +1,6 @@
 import { renderDashboardPage } from "./templates/dashboard.js";
 import { renderLoginPage } from "./templates/login.js";
+import { renderTestEndpointsPage } from "./templates/test_endpoints.js";
 
 const loginAttempts = new Map();
 const MAX_ATTEMPTS = 5;
@@ -117,6 +118,18 @@ export default {
         headers: { "content-type": "text/html; charset=UTF-8" },
       });
     }
+
+      if (url.pathname === "/test-endpoints") {
+        if (!loggedIn) {
+          return new Response("", {
+            status: 302,
+            headers: { Location: "/" },
+          });
+        }
+        return new Response(renderTestEndpointsPage(username), {
+          headers: { "content-type": "text/html; charset=UTF-8" },
+        });
+      }
 
     if (url.pathname === "/new_schema") {
       if (!loggedIn) {


### PR DESCRIPTION
## Summary
- add Test Endpoints HTML template that fetches `/api/grants`
- expose `/test-endpoints` route for logged-in users to load the new page
- link to the Test Endpoints view from the dashboard for easy access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8f725b6d48332a5f1a5aa2bae89a9