### PR TITLE
Add SoC pipeline worker with R2 batching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Run `npm test` before committing to verify repository checks pass.
 | UploadWorker   | Store uploaded PDFs in R2 for downstream extraction | POST to `/upload` with file or `{name,data}` | PDF object in `PDF_BUCKET`                   | `npx wrangler dev --local`          | On demand           | `worker/src/worker.ts` |
 | ExtractionWorker | Convert PDFs to summaries via grant_summarizer | Queue message `{key}` from `PDF_INGEST`    | CSV and Markdown files in `PDF_BUCKET`       | `npx wrangler dev src/pdf_worker.ts --local` | On `PDF_INGEST` message | `worker/src/pdf_worker.ts` |
 | ScoringWorker  | Score extracted rows and persist results        | Queue message `{file}` from `SCORE_QUEUE`  | Scored CSV in `PDF_BUCKET`                   | `npx wrangler dev src/score_worker.ts --local` | On `SCORE_QUEUE` message | `worker/src/score_worker.ts` |
+| SoCPipeline    | Batch SoC readings and write to R2              | POST JSON `{soc}`                          | Batched JSON in `SOC_BUCKET`                 | `npx wrangler dev workers/soc_pipeline_worker.js --local` | On demand           | `workers/soc_pipeline_worker.js` |
 
 # AGENTS.md (for `ui/` components)
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,36 @@ Store each user's weight profile as JSON in the `USER_PROFILES` KV namespace
 to control how grants are scored. If the binding isn't configured, scoring
 defaults to zero for all grants.
 
+## SoC pipeline worker
+
+The `soc_pipeline_worker.js` batches State of Charge readings and periodically
+writes them to an R2 bucket.
+
+### Environment variables
+
+- `BATCH_SIZE` – number of readings to accumulate before writing a batch (defaults to 10).
+- `SOC_BUCKET` – R2 binding name configured in `wrangler.toml`.
+
+### Deployment
+
+1. Create the R2 bucket:
+
+   ```bash
+   wrangler r2 bucket create soc-pipeline
+   ```
+
+2. Deploy the worker:
+
+   ```bash
+   wrangler deploy soc_pipeline
+   ```
+
+3. (Optional) configure a custom batch size:
+
+   ```bash
+   wrangler secret put BATCH_SIZE
+   ```
+
 ## Developer guide
 
 For guidelines on extending the backend, Cloudflare worker, or UI, see

--- a/workers/soc_pipeline_worker.js
+++ b/workers/soc_pipeline_worker.js
@@ -1,0 +1,23 @@
+// Worker to batch SoC readings and persist to R2
+const readings = [];
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+    try {
+      const data = await request.json();
+      readings.push({ ...data, ts: Date.now() });
+      const batchSize = Number(env.BATCH_SIZE) || 10;
+      if (readings.length >= batchSize) {
+        const key = `soc_batch_${Date.now()}.json`;
+        await env.SOC_BUCKET.put(key, JSON.stringify(readings));
+        readings.length = 0;
+      }
+      return new Response('accepted', { status: 202 });
+    } catch (err) {
+      return new Response('invalid payload', { status: 400 });
+    }
+  }
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,3 +24,10 @@ id = "065f64c71e0747079a2e3d86b292770d"
 
 
 
+
+[soc_pipeline]
+main = "workers/soc_pipeline_worker.js"
+
+[[soc_pipeline.r2_buckets]]
+binding = "SOC_BUCKET"
+bucket_name = "soc-pipeline"


### PR DESCRIPTION
## Summary
- implement `soc_pipeline_worker.js` to batch SoC readings and persist batches to an R2 bucket
- configure `soc_pipeline` service and R2 binding in `wrangler.toml`
- document SoC pipeline environment variables and deployment steps in `README`
- register SoC pipeline in AGENTS table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90b6611648332926248d7e7f3f558