### PR TITLE
feat: record SoC readings via new endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ Store each user's weight profile as JSON in the `USER_PROFILES` KV namespace
 to control how grants are scored. If the binding isn't configured, scoring
 defaults to zero for all grants.
 
+### State of charge endpoint
+
+The Worker exposes `/api/soc` for recording battery state-of-charge readings.
+Send a `POST` request with JSON such as `{"soc": 80, "timestamp": "2024-01-01T00:00:00Z"}`
+where `soc` is a percentage between 0 and 100 and `timestamp` is optional. Each
+valid reading is written to the `soc_readings` D1 table.
+
+```bash
+curl -X POST https://your-worker.example/api/soc \
+  -H "Content-Type: application/json" \
+  -d '{"soc": 82.5}'
+```
+
 ## Developer guide
 
 For guidelines on extending the backend, Cloudflare worker, or UI, see

--- a/docs/data_contract.json
+++ b/docs/data_contract.json
@@ -1,24 +1,38 @@
 {
-  "table": "programs",
-  "description": "D1 table storing scored grant programs.",
-  "fields": [
-    {"name": "Type", "type": "TEXT", "description": "Program category"},
-    {"name": "Name", "type": "TEXT", "primary_key": true, "description": "Program name"},
-    {"name": "Sponsor", "type": "TEXT", "description": "Sponsoring organization"},
-    {"name": "Source URL", "type": "TEXT", "description": "Link to program details"},
-    {"name": "Region / Eligibility", "type": "TEXT", "description": "Eligible region or requirements"},
-    {"name": "Deadline / Next Cohort", "type": "TEXT", "description": "Application deadline or next cohort date"},
-    {"name": "Cadence", "type": "TEXT", "description": "Program frequency"},
-    {"name": "Benefits", "type": "TEXT", "description": "Benefits offered"},
-    {"name": "Eligibility (key conditions)", "type": "TEXT", "description": "Key eligibility criteria"},
-    {"name": "Stage", "type": "TEXT", "description": "Target startup stage"},
-    {"name": "Non-dilutive?", "type": "TEXT", "description": "Whether funding is non-dilutive"},
-    {"name": "Stack Required?", "type": "TEXT", "description": "Whether sponsor stack is required"},
-    {"name": "Relevance", "type": "TEXT", "description": "Relevance score"},
-    {"name": "Fit", "type": "TEXT", "description": "Fit score"},
-    {"name": "Ease", "type": "TEXT", "description": "Ease score"},
-    {"name": "Weighted Score", "type": "TEXT", "description": "Combined weighted score"},
-    {"name": "Notes / Actions", "type": "TEXT", "description": "Notes or next actions"}
-  ],
-  "scoring_rules": "Relevance, Fit, and Ease are scored 0-3 and aggregated into Weighted Score. Update this contract when schemas or scoring rules change."
+  "tables": [
+    {
+      "name": "programs",
+      "description": "D1 table storing scored grant programs.",
+      "fields": [
+        {"name": "Type", "type": "TEXT", "description": "Program category"},
+        {"name": "Name", "type": "TEXT", "primary_key": true, "description": "Program name"},
+        {"name": "Sponsor", "type": "TEXT", "description": "Sponsoring organization"},
+        {"name": "Source URL", "type": "TEXT", "description": "Link to program details"},
+        {"name": "Region / Eligibility", "type": "TEXT", "description": "Eligible region or requirements"},
+        {"name": "Deadline / Next Cohort", "type": "TEXT", "description": "Application deadline or next cohort date"},
+        {"name": "Cadence", "type": "TEXT", "description": "Program frequency"},
+        {"name": "Benefits", "type": "TEXT", "description": "Benefits offered"},
+        {"name": "Eligibility (key conditions)", "type": "TEXT", "description": "Key eligibility criteria"},
+        {"name": "Stage", "type": "TEXT", "description": "Target startup stage"},
+        {"name": "Non-dilutive?", "type": "TEXT", "description": "Whether funding is non-dilutive"},
+        {"name": "Stack Required?", "type": "TEXT", "description": "Whether sponsor stack is required"},
+        {"name": "Relevance", "type": "TEXT", "description": "Relevance score"},
+        {"name": "Fit", "type": "TEXT", "description": "Fit score"},
+        {"name": "Ease", "type": "TEXT", "description": "Ease score"},
+        {"name": "Weighted Score", "type": "TEXT", "description": "Combined weighted score"},
+        {"name": "Notes / Actions", "type": "TEXT", "description": "Notes or next actions"}
+      ],
+      "scoring_rules": "Relevance, Fit, and Ease are scored 0-3 and aggregated into Weighted Score. Update this contract when schemas or scoring rules change."
+    },
+    {
+      "name": "soc_readings",
+      "description": "D1 table storing state of charge readings.",
+      "fields": [
+        {"name": "id", "type": "INTEGER", "primary_key": true, "description": "Auto-incrementing identifier"},
+        {"name": "ts", "type": "TEXT", "description": "Timestamp in ISO 8601 format"},
+        {"name": "soc", "type": "REAL", "description": "State of charge percentage"}
+      ]
+    }
+  ]
 }
+


### PR DESCRIPTION
## Summary
- add `/api/soc` endpoint that validates input and stores readings in new `soc_readings` D1 table
- document SoC schema in `docs/data_contract.json`
- explain how to submit SoC readings in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b90b83669483328140e3e8a4cb645b