### PR TITLE
Handle SSL errors and add certifi dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openpyxl
 flask
 plotly
 pyyaml
+certifi


### PR DESCRIPTION
## Summary
- use certifi-backed SSL context in `_get_json`
- catch URLError and SSLError and return empty dict on failure
- add certifi to requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b917ec1e208332b51279513caa2227