### PR TITLE
Handle missing plotly dependency gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The page includes a dataset selector letting you switch between
 missing, the app falls back to tiny sample data so the visualization can still
 be demoed.
 
+This visualization uses the optional `plotly` package for its charts. Install it
+with `pip install plotly` to enable interactive graphs; without it, the app
+runs but displays a friendly message instead of charts.
+
 ## Beginner installation
 
 If you're new to Python or Node.js, the following steps walk through a fresh

--- a/visualize_grants_web.py
+++ b/visualize_grants_web.py
@@ -11,8 +11,16 @@ Use the drop-down to switch between datasets.
 
 from pathlib import Path
 
+import logging
 import pandas as pd
-import plotly.express as px
+
+try:  # Plotly is optional for visualization
+    import plotly.express as px
+except ImportError:  # pragma: no cover - graceful degradation
+    px = None
+    logging.warning(
+        "plotly is not installed; run 'pip install plotly' to enable charts"
+    )
 from flask import (
     Flask,
     render_template_string,
@@ -62,7 +70,11 @@ def index():
     else:
         df = default_df
 
-    if {x_col, y_col}.issubset(df.columns):
+    if px is None:
+        graph_html = (
+            "<p>plotly is not installed. Install it to view interactive charts.</p>"
+        )
+    elif {x_col, y_col}.issubset(df.columns):
         fig = px.bar(df, x=x_col, y=y_col, title=title)
         graph_html = fig.to_html(full_html=False, include_plotlyjs="cdn")
     else:


### PR DESCRIPTION
## Summary
- make plotting optional by catching `plotly` import errors in `visualize_grants_web.py`
- note `plotly` as an optional dependency in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b917fd54a483328b2b1115a622a4d9