### PR TITLE
Ensure full programs schema in worker

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -20,7 +20,25 @@ async function getColumns(db) {
 }
 
 async function ensureProgramsTable(db) {
-  await db.exec("CREATE TABLE IF NOT EXISTS programs (id INTEGER PRIMARY KEY)");
+  await db.exec(`CREATE TABLE IF NOT EXISTS programs (
+    "Type" TEXT,
+    "Name" TEXT PRIMARY KEY,
+    "Sponsor" TEXT,
+    "Source URL" TEXT,
+    "Region / Eligibility" TEXT,
+    "Deadline / Next Cohort" TEXT,
+    "Cadence" TEXT,
+    "Benefits" TEXT,
+    "Eligibility (key conditions)" TEXT,
+    "Stage" TEXT,
+    "Non-dilutive?" TEXT,
+    "Stack Required?" TEXT,
+    "Relevance" TEXT,
+    "Fit" TEXT,
+    "Ease" TEXT,
+    "Weighted Score" TEXT,
+    "Notes / Actions" TEXT
+  );`);
 }
 
 async function newSchemaPage(db) {


### PR DESCRIPTION
## Summary
- mirror D1 migration schema in `ensureProgramsTable` so `programs` table includes all columns

## Testing
- `node /tmp/test_worker.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9271ea6c08332a75db5e592f6bbb8