### PR TITLE
Load SQL migrations and persist login attempts

### DIFF
--- a/docs/data_contract.json
+++ b/docs/data_contract.json
@@ -1,24 +1,37 @@
 {
-  "table": "programs",
-  "description": "D1 table storing scored grant programs.",
-  "fields": [
-    {"name": "Type", "type": "TEXT", "description": "Program category"},
-    {"name": "Name", "type": "TEXT", "primary_key": true, "description": "Program name"},
-    {"name": "Sponsor", "type": "TEXT", "description": "Sponsoring organization"},
-    {"name": "Source URL", "type": "TEXT", "description": "Link to program details"},
-    {"name": "Region / Eligibility", "type": "TEXT", "description": "Eligible region or requirements"},
-    {"name": "Deadline / Next Cohort", "type": "TEXT", "description": "Application deadline or next cohort date"},
-    {"name": "Cadence", "type": "TEXT", "description": "Program frequency"},
-    {"name": "Benefits", "type": "TEXT", "description": "Benefits offered"},
-    {"name": "Eligibility (key conditions)", "type": "TEXT", "description": "Key eligibility criteria"},
-    {"name": "Stage", "type": "TEXT", "description": "Target startup stage"},
-    {"name": "Non-dilutive?", "type": "TEXT", "description": "Whether funding is non-dilutive"},
-    {"name": "Stack Required?", "type": "TEXT", "description": "Whether sponsor stack is required"},
-    {"name": "Relevance", "type": "TEXT", "description": "Relevance score"},
-    {"name": "Fit", "type": "TEXT", "description": "Fit score"},
-    {"name": "Ease", "type": "TEXT", "description": "Ease score"},
-    {"name": "Weighted Score", "type": "TEXT", "description": "Combined weighted score"},
-    {"name": "Notes / Actions", "type": "TEXT", "description": "Notes or next actions"}
-  ],
-  "scoring_rules": "Relevance, Fit, and Ease are scored 0-3 and aggregated into Weighted Score. Update this contract when schemas or scoring rules change."
+  "tables": [
+    {
+      "name": "programs",
+      "description": "D1 table storing scored grant programs.",
+      "fields": [
+        {"name": "Type", "type": "TEXT", "description": "Program category"},
+        {"name": "Name", "type": "TEXT", "primary_key": true, "description": "Program name"},
+        {"name": "Sponsor", "type": "TEXT", "description": "Sponsoring organization"},
+        {"name": "Source URL", "type": "TEXT", "description": "Link to program details"},
+        {"name": "Region / Eligibility", "type": "TEXT", "description": "Eligible region or requirements"},
+        {"name": "Deadline / Next Cohort", "type": "TEXT", "description": "Application deadline or next cohort date"},
+        {"name": "Cadence", "type": "TEXT", "description": "Program frequency"},
+        {"name": "Benefits", "type": "TEXT", "description": "Benefits offered"},
+        {"name": "Eligibility (key conditions)", "type": "TEXT", "description": "Key eligibility criteria"},
+        {"name": "Stage", "type": "TEXT", "description": "Target startup stage"},
+        {"name": "Non-dilutive?", "type": "TEXT", "description": "Whether funding is non-dilutive"},
+        {"name": "Stack Required?", "type": "TEXT", "description": "Whether sponsor stack is required"},
+        {"name": "Relevance", "type": "TEXT", "description": "Relevance score"},
+        {"name": "Fit", "type": "TEXT", "description": "Fit score"},
+        {"name": "Ease", "type": "TEXT", "description": "Ease score"},
+        {"name": "Weighted Score", "type": "TEXT", "description": "Combined weighted score"},
+        {"name": "Notes / Actions", "type": "TEXT", "description": "Notes or next actions"}
+      ],
+      "scoring_rules": "Relevance, Fit, and Ease are scored 0-3 and aggregated into Weighted Score. Update this contract when schemas or scoring rules change."
+    },
+    {
+      "name": "login_attempts",
+      "description": "Tracks login attempt counts per IP for lockout logic.",
+      "fields": [
+        {"name": "ip", "type": "TEXT", "primary_key": true, "description": "Client IP address"},
+        {"name": "count", "type": "INTEGER", "description": "Failed login attempt count"},
+        {"name": "time", "type": "INTEGER", "description": "Unix ms timestamp of last attempt"}
+      ]
+    }
+  ]
 }

--- a/worker/migrations/0002_create_login_attempts.sql
+++ b/worker/migrations/0002_create_login_attempts.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS login_attempts (
+  ip TEXT PRIMARY KEY,
+  count INTEGER,
+  time INTEGER
+);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -47,16 +47,3 @@
     }
   ]
 } */
-
-/* name = "grant-demo"
-main = "worker.js"
-compatibility_date = "2024-05-29"
-
-# wrangler.toml (wrangler v3.88.0^)
-[observability.logs]
-enabled = true
-
-[vars]
-USER_HASHES = '{"admin":"713bfda78870bf9d1b261f565286f85e97ee614efe5f0faf7c34e7ca4f65baca","user":"05d49692b755f99c4504b510418efeeeebfd466892540f27acf9a31a326d6504"}'
-
- */

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,8 +6,7 @@ compatibility_date = "2024-05-29"
 [observability.logs]
 enabled = true
 
-[vars]
-USER_HASHES = '{"admin":"713bfda78870bf9d1b261f565286f85e97ee614efe5f0faf7c34e7ca4f65baca","user":"05d49692b755f99c4504b510418efeeeebfd466892540f27acf9a31a326d6504"}'
+rules = [{ type = "Text", globs = ["worker/migrations/*.sql"] }]
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary
- configure Wrangler to bundle SQL migrations
- persist login attempt counters in D1 instead of memory
- remove hard-coded user hashes from configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93e23e8348332a8ba1fbee1b4f30b