### PR TITLE
chore: mark sql migrations as text

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "grant-demo"
 main = "worker.js"
 compatibility_date = "2024-05-29"
+rules = [{ type = "Text", globs = ["worker/migrations/*.sql"] }]
 
 # wrangler.toml (wrangler v3.88.0^)
 [observability.logs]


### PR DESCRIPTION
## Summary
- Ensure Wrangler treats SQL migrations as plain text

## Testing
- `npm test`
- `npm run deploy` *(fails: CLOUDFLARE_API_TOKEN missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b946e974588332b5fdca8935772849