### PR TITLE
Use D1 migrations for programs table

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "scripts": {
     "test": "pytest grant_summarizer",
+    "predev": "wrangler d1 migrations apply EQORE_DB",
+    "predeploy": "wrangler d1 migrations apply EQORE_DB",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"
   },

--- a/worker.js
+++ b/worker.js
@@ -19,28 +19,6 @@ async function getColumns(db) {
   return results.map((r) => r.name);
 }
 
-async function ensureProgramsTable(db) {
-  await db.exec(`CREATE TABLE IF NOT EXISTS programs (
-    "Type" TEXT,
-    "Name" TEXT PRIMARY KEY,
-    "Sponsor" TEXT,
-    "Source URL" TEXT,
-    "Region / Eligibility" TEXT,
-    "Deadline / Next Cohort" TEXT,
-    "Cadence" TEXT,
-    "Benefits" TEXT,
-    "Eligibility (key conditions)" TEXT,
-    "Stage" TEXT,
-    "Non-dilutive?" TEXT,
-    "Stack Required?" TEXT,
-    "Relevance" TEXT,
-    "Fit" TEXT,
-    "Ease" TEXT,
-    "Weighted Score" TEXT,
-    "Notes / Actions" TEXT
-  );`);
-}
-
 async function newSchemaPage(db) {
   const columns = await getColumns(db);
   const inputs = columns
@@ -68,7 +46,6 @@ export default {
     const username = sessionMatch ? decodeURIComponent(sessionMatch[1]) : null;
     const loggedIn = !!username;
     const users = env.USER_HASHES ? JSON.parse(env.USER_HASHES) : {};
-    await ensureProgramsTable(env.DB);
 
     if (url.pathname === "/login" && request.method === "POST") {
       const form = await request.formData();


### PR DESCRIPTION
## Summary
- remove inline programs table creation from worker
- run `wrangler d1 migrations apply` before development and deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94387255c8332a070a12c6e214c4c