### PR TITLE
fix: run D1 migrations from worker directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "scripts": {
     "test": "pytest grant_summarizer",
-    "predev": "wrangler d1 migrations apply EQORE_DB",
-    "predeploy": "wrangler d1 migrations apply EQORE_DB",
+    "predev": "cd worker && wrangler d1 migrations apply EQORE_DB",
+    "predeploy": "cd worker && wrangler d1 migrations apply EQORE_DB",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"
   },


### PR DESCRIPTION
## Summary
- apply D1 migrations from the `worker/` directory in `predev` and `predeploy`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94f193628833282acfe75eaba69f6