### PR TITLE
Ensure full programs schema in worker

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,7 @@
 import { renderDashboardPage } from "./ui/dashboard.js";
 import { renderLoginPage } from "./ui/login.js";
 import { renderTestEndpointsPage } from "./ui/test_endpoints.js";
+import programsSchema from "./worker/migrations/0001_create_programs.sql?raw";
 
 const loginAttempts = new Map();
 const MAX_ATTEMPTS = 5;
@@ -19,8 +20,12 @@ async function getColumns(db) {
   return results.map((r) => r.name);
 }
 
+let ensured;
 async function ensureProgramsTable(db) {
-  await db.exec("CREATE TABLE IF NOT EXISTS programs (id INTEGER PRIMARY KEY)");
+  if (!ensured) {
+    ensured = db.exec(programsSchema);
+  }
+  await ensured;
 }
 
 async function newSchemaPage(db) {


### PR DESCRIPTION
## Summary
- import D1 migration SQL and execute it at startup so `programs` table is created with full schema
- await migration execution to finish before handling requests

## Testing
- `node /tmp/test_worker.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9271ea6c08332a75db5e592f6bbb8