### PR TITLE
feat: configure wrangler build rule for SQL migrations

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,7 @@
 import { renderDashboardPage } from "./ui/dashboard.js";
 import { renderLoginPage } from "./ui/login.js";
 import { renderTestEndpointsPage } from "./ui/test_endpoints.js";
+import programsSchema from "./worker/migrations/0001_create_programs.sql";
 
 const MAX_ATTEMPTS = 5;
 const LOCKOUT_MS = 5 * 60 * 1000;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,12 @@
 name = "grant-demo"
 main = "worker.js"
 compatibility_date = "2024-05-29"
-rules = [{ type = "Text", globs = ["worker/migrations/*.sql"] }]
+
+[build.upload]
+
+[[build.upload.rules]]
+globs = ["worker/migrations/*.sql"]
+type = "Text"
 
 # wrangler.toml (wrangler v3.88.0^)
 [observability.logs]


### PR DESCRIPTION
## Summary
- use `[build.upload.rules]` in `wrangler.toml` for SQL migrations
- import `programsSchema` without `?raw`

## Testing
- `npx wrangler versions upload` *(fails: requires CLOUDFLARE_API_TOKEN)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b95c14f3748332b6d25cfff286bb65