### PR TITLE
Fix Grants.gov keyword parameter usage

### DIFF
--- a/grant_summarizer/README.md
+++ b/grant_summarizer/README.md
@@ -23,6 +23,8 @@ grant-summarizer --url https://example.com/grant.html --allow-online --format al
 
 # Search grants.gov for opportunities
 grant-summarizer --search water --outdir ./dist
+
+This uses the Grants.gov API's `keyword` parameter.
 ```
 
 By default the tool operates offline and only accepts local paths or `file://` URLs. Using `--allow-online` enables downloading content from remote hosts, which may expose the system to malicious files or unexpected network traffic. Only use this flag if you trust the source.

--- a/grant_summarizer/grant_summarizer/grants_api.py
+++ b/grant_summarizer/grant_summarizer/grants_api.py
@@ -8,6 +8,7 @@ API_URL = "https://www.grants.gov/grantsws/rest/opportunities/search"
 
 def search_grants(keyword: str, limit: int = 10) -> List[Dict]:
     """Search the grants.gov API for opportunities matching ``keyword``."""
+    # The API uses the singular "keyword" query parameter.
     params = urlencode({"keyword": keyword, "limit": limit})
     with urlopen(f"{API_URL}?{params}", timeout=10) as resp:
         data = json.load(resp)

--- a/grant_summarizer/tests/test_grants_api.py
+++ b/grant_summarizer/tests/test_grants_api.py
@@ -10,5 +10,8 @@ def test_search_grants():
     fake_bytes = json.dumps(fake_json).encode("utf-8")
     with patch("grant_summarizer.grants_api.urlopen", return_value=BytesIO(fake_bytes)) as mock_urlopen:
         results = search_grants("water", limit=1)
+        mock_urlopen.assert_called_once_with(
+            "https://www.grants.gov/grantsws/rest/opportunities/search?keyword=water&limit=1",
+            timeout=10,
+        )
     assert results == fake_json["opportunities"]
-    mock_urlopen.assert_called_once()

--- a/search_grants.py
+++ b/search_grants.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Search Grants.gov and export results.
 
-This CLI queries the Grants.gov search API using keywords and optional filters,
+This CLI queries the Grants.gov search API using the ``keyword`` parameter and optional filters,
 then enriches each opportunity with details from the opportunity synopsis
 endpoint. Results can be written to CSV or TSV and a curated summary table is
 printed for quick review.
@@ -45,7 +45,8 @@ def _get_json(url: str, params: Dict[str, str] | None = None, debug: bool = Fals
 
 def search_grants(keyword: str, filters: Dict[str, str], debug: bool = False) -> List[Dict]:
     """Return a list of opportunities matching ``keyword`` and ``filters``."""
-    params = {"keywords": keyword, "limit": "20", **filters}
+    # The Grants.gov API expects the singular "keyword" parameter.
+    params = {"keyword": keyword, "limit": "20", **filters}
     data = _get_json(SEARCH_URL, params, debug=debug)
     return data.get("opportunities", [])
 


### PR DESCRIPTION
## Summary
- use singular `keyword` parameter when querying Grants.gov
- clarify API usage in docs and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b97ec60b6c8332af81bd5f6c350b84