### PR TITLE
Add tests for search_grants workflow

### DIFF
--- a/grant_summarizer/tests/test_search_grants.py
+++ b/grant_summarizer/tests/test_search_grants.py
@@ -1,0 +1,65 @@
+import json
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Ensure repository root is on the import path to load search_grants.py
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from search_grants import _post_json, search_grants as do_search, fetch_detail, SEARCH_URL
+
+
+def test_post_json_sends_body_and_headers():
+    payload = {"a": 1}
+    captured = {}
+
+    class FakeResponse:
+        status = 200
+
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_urlopen(req, context=None):
+        captured["req"] = req
+        return FakeResponse()
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        _post_json(SEARCH_URL, payload)
+
+    req = captured["req"]
+    assert req.headers["Content-type"] == "application/json"
+    assert req.headers["Accept"] == "application/json"
+    assert json.loads(req.data.decode("utf-8")) == payload
+
+
+def test_search_grants_success():
+    fake = {"opportunities": [{"id": 1}]}
+    with patch("search_grants._post_json", return_value=fake) as mock_post:
+        results = do_search("water", {"f": "v"})
+    assert results == fake["opportunities"]
+    mock_post.assert_called_once_with(
+        SEARCH_URL, {"keywords": "water", "limit": "20", "f": "v"}, debug=False
+    )
+
+
+def test_search_grants_failure(caplog):
+    with patch("search_grants._post_json", side_effect=RuntimeError("boom")):
+        with caplog.at_level(logging.ERROR):
+            results = do_search("x", {})
+    assert results == []
+    assert "Search request failed" in caplog.text
+
+
+def test_fetch_detail_failure(caplog):
+    with patch("search_grants._get_json", side_effect=RuntimeError("bad")):
+        with caplog.at_level(logging.ERROR):
+            result = fetch_detail("123")
+    assert result == {}
+    assert "Detail request for 123 failed" in caplog.text


### PR DESCRIPTION
## Summary
- add unit tests covering _post_json payload and headers
- ensure search_grants and fetch_detail log and handle failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98bdc71148332825e31195cf0d21b