### PR TITLE
Use GET for Grants.gov search

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,9 @@ python search_grants.py education --filter opportunityStatuses=posted --output r
 python wrangle_grants.py --input examples/grants_demo --out out/demo.csv --print-summary
 ```
 
+`search_grants.py` now queries the Grants.gov API with HTTP GET requests, sending
+keywords and filters as query parameters (e.g., `?keywords=education&limit=20`).
+If the API responds with a non-200 status, the script logs the error and returns
+no results.
+
 See [docs/README.md](docs/README.md) for detailed features and additional documentation.

--- a/search_grants.py
+++ b/search_grants.py
@@ -18,7 +18,7 @@ import urllib.parse
 import urllib.request
 import ssl
 import certifi
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import pandas as pd
 
@@ -52,36 +52,11 @@ def _get_json(url: str, params: Dict[str, str] | None = None, debug: bool = Fals
         raise RuntimeError(f"Invalid JSON from {url}: {err}") from err
 
 
-def _post_json(url: str, payload: Dict[str, Any], debug: bool = False) -> Dict:
-    """POST ``payload`` as JSON to ``url`` and return the decoded response."""
-    headers = {"Content-Type": "application/json", "Accept": "application/json"}
-    body = json.dumps(payload).encode("utf-8")
-    logging.debug("POST %s", url)
-    context = ssl.create_default_context(cafile=certifi.where())
-    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-    try:
-        with urllib.request.urlopen(req, context=context) as resp:  # noqa: S310 - network call intended
-            text = resp.read().decode("utf-8")
-            if resp.status != 200:
-                raise RuntimeError(f"Request to {url} failed with {resp.status}: {text[:200]}")
-    except urllib.error.HTTPError as err:  # pragma: no cover - network error handling
-        body = err.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"Request to {url} failed with {err.code}: {body[:200]}") from err
-    except (urllib.error.URLError, ssl.SSLError) as err:  # pragma: no cover - network error handling
-        raise RuntimeError(f"Failed to fetch {url}: {err}") from err
-    if debug:
-        logging.debug("Response: %s", text[:1000])
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as err:  # pragma: no cover - defensive
-        raise RuntimeError(f"Invalid JSON from {url}: {err}") from err
-
-
 def search_grants(keyword: str, filters: Dict[str, str], debug: bool = False) -> List[Dict]:
     """Return a list of opportunities matching ``keyword`` and ``filters``."""
-    payload = {"keywords": keyword, "limit": "20", **filters}
+    params = {"keywords": keyword, "limit": "20", **filters}
     try:
-        data = _post_json(SEARCH_URL, payload, debug=debug)
+        data = _get_json(SEARCH_URL, params, debug=debug)
     except RuntimeError as err:
         logging.error("Search request failed: %s", err)
         return []


### PR DESCRIPTION
## Summary
- query Grants.gov search API with HTTP GET parameters instead of POST
- log failures when the API returns non-200 responses
- document GET usage and error handling in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d93bfea88332b8a950ff869e1a9b