### PR TITLE
fix: include workers types

### DIFF
--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -1,3 +1,4 @@
+/// <reference types="@cloudflare/workers-types" />
 import { Ai } from '@cloudflare/ai';
 
 export interface Env {

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "types": ["@cloudflare/workers-types"],
     "target": "es2021",
-    "lib": ["es2021"]
+    "lib": ["es2021", "DOM"],
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Summary
- add Cloudflare Workers typings reference to worker code
- configure TypeScript with DOM libs, bundler resolution, and skip library checks

## Testing
- `npx tsc -p worker/tsconfig.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9ec6dce3c8332bc53fc31ea575f51