### PR TITLE
Refactor login record initialization

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -52,14 +52,14 @@ export default {
       const pass = form.get("password");
       const ip = request.headers.get("CF-Connecting-IP") || "unknown";
       const now = Date.now();
-      let record = { count: 0, time: now };
+      let record;
       if (env.LOGIN_ATTEMPTS) {
-        const stored = await env.LOGIN_ATTEMPTS.get(ip, { type: "json" });
-        if (stored) {
-          record = stored;
-        }
+        record = await env.LOGIN_ATTEMPTS.get(ip, { type: "json" });
       } else {
         console.warn("LOGIN_ATTEMPTS binding is not configured");
+      }
+      if (!record) {
+        record = { count: 0, time: now };
       }
       if (now - record.time > LOCKOUT_MS) {
         record.count = 0;


### PR DESCRIPTION
## Summary
- simplify login attempt record retrieval by using a single mutable variable

## Testing
- `npm test`
- `npx wrangler versions upload` *(fails: CLOUDFLARE_API_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ab43f08833286aa1cd1168c13de