### PR TITLE
Add default demo login for Worker

### DIFF
--- a/ui/login.js
+++ b/ui/login.js
@@ -2,9 +2,10 @@ export function renderLoginPage() {
   return `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"><title>Grant Login</title></head>
-<body>
-  <h1>Grant Wrangler Demo</h1>
-  <form method="POST" action="/login">
+  <body>
+    <h1>Grant Wrangler Demo</h1>
+  <p>Use username <code>demo</code> and password <code>demo</code> to log in.</p>
+    <form method="POST" action="/login">
     <label>Username <input name="username" /></label><br />
     <label>Password <input type="password" name="password" /></label><br />
     <button type="submit">Login</button>

--- a/worker.js
+++ b/worker.js
@@ -44,7 +44,14 @@ export default {
     const sessionMatch = cookie.match(/session=([^;]+)/);
     const username = sessionMatch ? decodeURIComponent(sessionMatch[1]) : null;
     const loggedIn = !!username;
-    const users = env.USER_HASHES ? JSON.parse(env.USER_HASHES) : {};
+    // Provide a default demo login so the worker is usable out of the box.
+    // The password "demo" is hashed using SHA-256 so it can live alongside
+    // any additional users supplied via the USER_HASHES binding.
+    const defaultUsers = {
+      demo: "2a97516c354b68848cdbd8f54a226a0a55b21ed138e207ad6c5cbb9c00aa5aea",
+    };
+    const envUsers = env.USER_HASHES ? JSON.parse(env.USER_HASHES) : {};
+    const users = { ...defaultUsers, ...envUsers };
 
     if (url.pathname === "/login" && request.method === "POST") {
       const form = await request.formData();


### PR DESCRIPTION
## Summary
- include a built-in `demo` user hashed in worker.js to avoid unauthorized errors
- note demo credentials on login page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4997872c83328162a009371e7f87