### PR TITLE
Add default demo login for Worker

### DIFF
--- a/ui/login.js
+++ b/ui/login.js
@@ -2,9 +2,10 @@ export function renderLoginPage() {
   return `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"><title>Grant Login</title></head>
-<body>
-  <h1>Grant Wrangler Demo</h1>
-  <form method="POST" action="/login">
+  <body>
+    <h1>Grant Wrangler Demo</h1>
+  <p>Use username <code>demo</code> and password <code>demo</code> to log in.</p>
+    <form method="POST" action="/login">
     <label>Username <input name="username" /></label><br />
     <label>Password <input type="password" name="password" /></label><br />
     <button type="submit">Login</button>


### PR DESCRIPTION
## Summary
- include a built-in `demo` user hashed in worker.js to avoid unauthorized errors
- note demo credentials on login page
- hash demo credentials at runtime and support plain-text `USER_HASHES` entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4997872c83328162a009371e7f87