### PR TITLE
Use native AI binding for worker AI calls

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -7,21 +7,11 @@
     "": {
       "name": "worker-demo",
       "version": "1.0.0",
-      "dependencies": {
-        "@cloudflare/ai": "^1.0.0"
-      },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250903.0",
         "typescript": "^5.0.0",
         "wrangler": "^3.0.0"
       }
-    },
-    "node_modules/@cloudflare/ai": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/ai/-/ai-1.2.2.tgz",
-      "integrity": "sha512-dT4gUPKWUERoTHHrbUrhJBIP8P9k6qybw5fK4bnqSAyTL9AvU98D7z6SOT/BwvmOhYA8hzBGNRbQsXyvxniGyA==",
-      "deprecated": "Thanks for using @cloudflare/ai: This package has been deprecated in favor of the native binding, learn more here https://developers.cloudflare.com/workers-ai/configuration/bindings/ ",
-      "license": "MIT"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.3.4",

--- a/worker/package.json
+++ b/worker/package.json
@@ -7,9 +7,6 @@
     "deploy": "wrangler deploy",
     "test": "echo \"No tests\""
   },
-  "dependencies": {
-    "@cloudflare/ai": "^1.0.0"
-  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250903.0",
     "typescript": "^5.0.0",

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -1,9 +1,12 @@
 /// <reference types="@cloudflare/workers-types" />
-import { Ai } from '@cloudflare/ai';
+
+interface AiBinding {
+  run(model: string, input: unknown): Promise<any>;
+}
 
 export interface Env {
   PDF_BUCKET: R2Bucket;
-  AI: Ai;
+  AI: AiBinding;
 }
 
 const corsHeaders = {
@@ -72,8 +75,7 @@ export default {
           headers: { ...corsHeaders, 'content-type': 'application/json' }
         });
       }
-      const ai = new Ai(env.AI);
-      const result = await ai.run('@cf/meta/llama-3-8b-instruct', { prompt });
+      const result = await env.AI.run('@cf/meta/llama-3-8b-instruct', { prompt });
       return new Response(JSON.stringify(result), {
         headers: { ...corsHeaders, 'content-type': 'application/json' }
       });


### PR DESCRIPTION
## Summary
- Remove deprecated `@cloudflare/ai` package and rely on Cloudflare's native AI binding
- Simplify worker environment interface and call `env.AI.run` directly

## Testing
- `npm test`
- `npx esbuild worker/src/worker.ts --bundle --outfile=worker/out.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba800f09d48332828072eb845210d3