### PR TITLE
docs: remove obsolete build step

### DIFF
--- a/AGENTS_AUTOMATION.md
+++ b/AGENTS_AUTOMATION.md
@@ -19,7 +19,6 @@ Follow this sequence to set up the system end to end:
    ```
 2. **Deploy `/upload` endpoint**
    ```bash
-   npm run build
    wrangler deploy
    ```
 3. **Run the extraction queue worker**

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,10 +22,7 @@
     "API_BASE_URL": "https://api.example.com"
   },
 
-  // Build step run before uploading your Worker
-  "build": {
-    "command": "npm run build"
-  },
+  // `wrangler deploy` automatically builds your Worker
 
   // Durable Object bindings
   "durable_objects": {


### PR DESCRIPTION
## Summary
- clarify deployment instructions: `wrangler deploy` builds workers so no separate `npm run build`
- remove unused build snippet from `wrangler.jsonc`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0ca5c6a08332ba93276b7855d4ba