### PR TITLE
Harden Flask portal debug settings and fix grant search utilities

### DIFF
--- a/grant_summarizer/grant_summarizer/grants_api.py
+++ b/grant_summarizer/grant_summarizer/grants_api.py
@@ -3,8 +3,9 @@ import json
 import logging
 import ssl
 import certifi
-from urllib.request import urlopen, Request
+from urllib.request import urlopen
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
 
 API_URL = "https://www.grants.gov/grantsws/rest/opportunities/search"
 
@@ -13,20 +14,9 @@ def search_grants(keyword: str, limit: int = 10) -> List[Dict]:
     """Search the grants.gov API for opportunities matching ``keyword``."""
     # The API uses the singular "keyword" query parameter.
     params = urlencode({"keyword": keyword, "limit": limit})
-    with urlopen(f"{API_URL}?{params}", timeout=10) as resp:
-        data = json.load(resp)
-    return data.get("opportunities", [])
-    payload = {"keywords": keyword, "limit": limit}
-    data = json.dumps(payload).encode("utf-8")
-    req = Request(API_URL, data=data, headers={"Content-Type": "application/json"}, method="POST")
-    context = ssl.create_default_context(cafile=certifi.where())
     try:
-        with urlopen(req, timeout=10, context=context) as resp:
-            text = resp.read().decode("utf-8")
-            status = getattr(resp, "status", 200)
-            if status != 200:
-                logging.error("Search API returned %s: %s", status, text[:200])
-                return []
+        with urlopen(f"{API_URL}?{params}", timeout=10) as resp:
+            data = json.load(resp)
     except HTTPError as err:
         body = err.read().decode("utf-8", errors="replace")
         logging.error("Search API request failed with %s: %s", err.code, body[:200])
@@ -34,4 +24,4 @@ def search_grants(keyword: str, limit: int = 10) -> List[Dict]:
     except URLError as err:
         logging.error("Search API request failed: %s", err)
         return []
-    return json.loads(text).get("opportunities", [])
+    return data.get("opportunities", [])

--- a/search_grants.py
+++ b/search_grants.py
@@ -84,16 +84,15 @@ def _post_json(url: str, payload: Dict[str, Any], debug: bool = False) -> Dict:
 
 def search_grants(keyword: str, filters: Dict[str, str], debug: bool = False) -> List[Dict]:
     """Return a list of opportunities matching ``keyword`` and ``filters``."""
-    # The new search2 API uses POST with JSON payload
-    payload = {"keyword": keyword, "rows": 20, **filters}
+    # Legacy search endpoint expects "keywords" and a "limit" string parameter.
+    payload: Dict[str, Any] = {"keywords": keyword, "limit": "20"}
+    payload.update(filters)
     try:
         response = _post_json(SEARCH_URL, payload, debug=debug)
     except RuntimeError as err:
         logging.error("Search request failed: %s", err)
         return []
-    # The new API nests opportunities under data.oppHits
-    data = response.get("data", {})
-    return data.get("oppHits", [])
+    return response.get("opportunities", [])
 
 
 def fetch_detail(opp_id: str, debug: bool = False) -> Dict:

--- a/visualize_grants_web.py
+++ b/visualize_grants_web.py
@@ -12,6 +12,7 @@ Use the drop-down to switch between datasets.
 from pathlib import Path
 
 import logging
+import os
 import pandas as pd
 
 try:  # Plotly is optional for visualization
@@ -199,4 +200,13 @@ def logout():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    host = os.environ.get("GRANT_PORTAL_HOST", "127.0.0.1")
+    debug_flag = os.environ.get("GRANT_PORTAL_DEBUG", "0") not in {"", "0", "false", "False"}
+
+    if host not in {"127.0.0.1", "localhost", "::1"} and debug_flag:
+        logging.warning(
+            "Disabling Flask debug mode because host %s is not loopback", host
+        )
+        debug_flag = False
+
+    app.run(host=host, debug=debug_flag)


### PR DESCRIPTION
## Summary
- add environment-controlled host/debug settings for the visualization portal and prevent debug mode when binding to non-loopback addresses
- restore the expected payload/response handling for the CLI search helpers and the internal grants.gov API wrapper

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d78cb8ae48332a206aa46fa95addd)