### PR TITLE
Add --print-summary flag to display merge statistics

### DIFF
--- a/wrangle_grants.py
+++ b/wrangle_grants.py
@@ -54,6 +54,7 @@ def main() -> None:
     ap.add_argument("--delimiter", dest="delimiter", default=",", help='CSV delimiter (default: ",")')
     ap.add_argument("--encoding", dest="encoding", default="utf-8", help='File encoding (default: "utf-8")')
     ap.add_argument("--strict", action="store_true", help="Fail if any file cannot be read")
+    ap.add_argument("--print-summary", action="store_true", help="Print summary statistics after merging")
     args = ap.parse_args()
 
     in_dir = args.in_dir
@@ -129,6 +130,13 @@ def main() -> None:
         w.writerows(normalized)
 
     print(f"OK: Merged {loaded} file(s) → {out_file} ({len(normalized)} rows)")
+
+    if args.print_summary:
+        print(f"\nSummary:")
+        print(f"  Files merged : {loaded}")
+        print(f"  Total rows   : {len(normalized)}")
+        print(f"  Columns ({len(union)}): {', '.join(union)}")
+
     sys.exit(0)
 
 


### PR DESCRIPTION
## Summary
Added a new optional `--print-summary` command-line flag that displays detailed summary statistics after merging grant files.

## Changes
- Added `--print-summary` argument to the argument parser with appropriate help text
- Implemented conditional summary output that displays:
  - Number of files merged
  - Total row count in the merged output
  - List of all columns present in the merged data
- Summary is only printed when the flag is explicitly provided, maintaining backward compatibility

## Implementation Details
The summary statistics are printed after the standard completion message and include the count of merged files, total rows in the normalized dataset, and a formatted list of all columns in the union schema. This provides users with quick visibility into the merge operation results without requiring them to inspect the output file directly.

https://claude.ai/code/session_01HFw87XW7cVE3WaTfJqBKd1