### PR TITLE
Replace pdfminer.six with pypdf for PDF text extraction

### DIFF
--- a/grant_summarizer/grant_summarizer/extract.py
+++ b/grant_summarizer/grant_summarizer/extract.py
@@ -18,19 +18,11 @@ WINDOW = 300
 
 
 def extract_text(pdf_path: str) -> str:
-    """Extract text from a PDF using pdfminer; fall back to PyPDF2."""
-    from pdfminer.high_level import extract_text as pdfminer_extract
+    """Extract text from a PDF using pypdf."""
+    from pypdf import PdfReader
 
-    path = Path(pdf_path)
-    try:
-        return pdfminer_extract(str(path))
-    except Exception:
-        try:
-            from PyPDF2 import PdfReader  # type: ignore
-        except Exception as exc:  # pragma: no cover - PyPDF2 absent
-            raise exc
-        reader = PdfReader(str(path))
-        return "\n".join(page.extract_text() or "" for page in reader.pages)
+    reader = PdfReader(str(Path(pdf_path)))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
 
 
 class _HTMLStripper(HTMLParser):

--- a/grant_summarizer/pyproject.toml
+++ b/grant_summarizer/pyproject.toml
@@ -7,7 +7,8 @@ name = "grant_summarizer"
 version = "0.1.0"
 dependencies = [
   "typer",
-  "pdfminer.six",
+  "pypdf>=3.0",
+  "cffi",
   "pydantic",
 ]
 


### PR DESCRIPTION
## Summary
Simplifies PDF text extraction by replacing the dual-fallback approach using pdfminer.six and PyPDF2 with a single, unified pypdf library implementation.

## Key Changes
- Removed pdfminer.six dependency and its associated import logic
- Eliminated the try-except fallback mechanism that attempted pdfminer first, then PyPDF2
- Replaced with direct pypdf (PyPDF2's successor) implementation for all PDF text extraction
- Updated dependencies in pyproject.toml:
  - Removed `pdfminer.six`
  - Added `pypdf>=3.0` as primary dependency
  - Added `cffi` as a transitive dependency requirement

## Implementation Details
The `extract_text()` function now uses pypdf's `PdfReader` directly without exception handling for fallbacks. This reduces code complexity from ~10 lines to ~5 lines while maintaining the same functionality of extracting and joining text from all PDF pages.

https://claude.ai/code/session_018QsMWyHnGqCAg68aQqnpY9