### PR TITLE
Separate Cloudflare Workers CI/CD into dedicated workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,21 +5,20 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+# Workers deployment is handled by workers-ci.yml
 jobs:
-  deploy:
+  test-and-check:
+    name: Python tests & JS sanity
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-    - name: Set up Node
-      uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.11"
 
@@ -30,26 +29,4 @@ jobs:
       run: npm ci
 
     - name: Run Python tests
-      run: pytest -q || true
-
-    - name: Create KV Namespaces if missing
-      run: |
-        npx wrangler kv:namespace create USER_PROFILES --environment production || true
-        npx wrangler kv:namespace create LOGIN_ATTEMPTS --environment production || true
-
-    - name: Apply D1 migrations
-      run: |
-        npx wrangler d1 migrations apply EQORE_DB --remote || true
-
-    - name: Deploy Worker
-      run: |
-        npx wrangler deploy --config wrangler.toml --env production
-
-    - name: Add deployment badge to README
-      run: |
-        echo "![Deploy Status](https://github.com/${{ github.repository }}/actions/workflows/deploy.yml/badge.svg)" > README.md
-        git config user.name "GitHub Actions"
-        git config user.email "actions@github.com"
-        git add README.md
-        git commit -m "Update deploy badge" || true
-        git push || true
+      run: pytest -q

--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -1,0 +1,81 @@
+name: Cloudflare Workers CI/CD
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - 'worker.js'
+      - 'wrangler.toml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - 'worker.js'
+      - 'wrangler.toml'
+  workflow_dispatch:
+
+jobs:
+  # ── Validate on every PR ──────────────────────────────────────────────────
+  validate:
+    name: Type-check & dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install worker deps
+        working-directory: worker
+        run: npm ci
+
+      - name: TypeScript type-check
+        working-directory: worker
+        run: npx tsc --noEmit
+
+      - name: Wrangler dry-run (validate config)
+        working-directory: worker
+        run: npx wrangler deploy --dry-run --outdir /tmp/worker-build
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  # ── Deploy only on push to main ───────────────────────────────────────────
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment:
+      name: production
+      url: https://grant-demo.workers.dev
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install worker deps
+        working-directory: worker
+        run: npm ci
+
+      - name: Apply D1 migrations
+        working-directory: worker
+        run: npx wrangler d1 migrations apply EQORE_DB --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        continue-on-error: true
+
+      - name: Deploy worker
+        working-directory: worker
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
Refactored CI/CD pipeline to separate Cloudflare Workers deployment into a dedicated workflow file, improving separation of concerns and making the deployment process more maintainable.

## Key Changes
- **New workflow**: Added `.github/workflows/workers-ci.yml` with dedicated CI/CD for Cloudflare Workers
  - Validation job: TypeScript type-checking and wrangler dry-run on all PRs and pushes
  - Deployment job: Applies D1 migrations and deploys worker only on push to main
  - Uses production environment with deployment URL tracking
  
- **Updated workflow**: Simplified `.github/workflows/deploy.yml`
  - Removed all Cloudflare Workers-related steps (KV namespace creation, D1 migrations, worker deployment)
  - Renamed job from `deploy` to `test-and-check` to reflect its new purpose
  - Now focuses solely on Python tests and JavaScript sanity checks
  - Removed deployment badge automation
  - Simplified step naming (removed redundant "name" fields where action name is self-explanatory)

## Implementation Details
- Workers CI/CD triggers on changes to `worker/`, `worker.js`, or `wrangler.toml` files
- Validation runs on both PRs and pushes; deployment only on main branch pushes
- Uses Node 20 with npm caching for faster builds
- Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets for deployment
- D1 migration failures are non-blocking (`continue-on-error: true`)

https://claude.ai/code/session_015ExanQ9TtjyPeUMwtGNidY