### PR TITLE
Add UI build pipeline and update deployment configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,13 @@ wrangle:
 visualize:
 	python visualize_grants_web.py
 
-deploy:
+build-ui:
+	cd ui && npm install && npm run build
+
+deploy: build-ui
 	wrangler deploy
 
-.PHONY: wrangle visualize deploy
+dev-ui:
+	cd ui && npm install && npm run dev
+
+.PHONY: wrangle visualize build-ui deploy dev-ui

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,9 @@ main = "worker.js"
 compatibility_date = "2024-05-29"
 workers_dev = true
 
-# This ensures all HTML/CSS/JS files get bundled
+[build]
+command = "cd ui && npm install && npm run build"
+
 assets = { directory = "ui/dist", not_found_handling = "single-page-application" }
 
 [[kv_namespaces]]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,7 +4,7 @@ compatibility_date = "2024-05-29"
 workers_dev = true
 
 # This ensures all HTML/CSS/JS files get bundled
-assets = { directory = "ui", not_found_handling = "single-page-application" }
+assets = { directory = "ui/dist", not_found_handling = "single-page-application" }
 
 [[kv_namespaces]]
 binding = "USER_PROFILES"


### PR DESCRIPTION
## Summary
This PR integrates a proper build pipeline for the UI layer and updates the deployment configuration to use built artifacts instead of raw source files.

## Key Changes
- **Added `build-ui` Makefile target**: Installs dependencies and builds the UI in the `ui` directory
- **Added `dev-ui` Makefile target**: Provides a convenient way to run the UI development server locally
- **Updated `deploy` target**: Now depends on `build-ui` to ensure the UI is compiled before deployment
- **Updated `wrangler.toml` build configuration**: 
  - Added explicit `[build]` section with command to build the UI
  - Changed assets directory from `ui` to `ui/dist` to serve the compiled output instead of source files
- **Updated `.PHONY` declaration**: Added new targets to the phony targets list

## Implementation Details
The changes establish a proper build workflow where:
1. The UI is built to a `dist` directory during the build process
2. Only the compiled artifacts in `ui/dist` are deployed as static assets
3. Developers can use `make dev-ui` for local development and `make deploy` for production deployments
4. The build step is automatically executed as part of the deployment process via Wrangler

https://claude.ai/code/session_01KeBEFZkcuP2G9MNRvJquGg