### PR TITLE
Remove PDF_INGEST queue consumer binding from wrangler config

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -23,9 +23,6 @@ binding = "PDF_BUCKET"
 bucket_name = "pdf-bucket"
 preview_bucket_name = "pdf-bucket"
 
-[[queues.consumers]]
-queue = "PDF_INGEST"
-
 [[services]]
 binding = "PDF_WORKER"
 service = "pdf-worker"


### PR DESCRIPTION
## Summary
Removed the queue consumer configuration for the PDF_INGEST queue from the Wrangler configuration file.

## Changes
- Removed the `[[queues.consumers]]` binding configuration that was routing the "PDF_INGEST" queue to a consumer

## Details
This change removes the queue consumer setup that was previously configured in the worker's Wrangler configuration. The PDF_INGEST queue consumer is no longer needed in this configuration, likely because the queue consumption logic has been moved elsewhere or is no longer required for this worker.

https://claude.ai/code/session_018pjyL7rF3TiMKJ8Nz2hzay