### PR TITLE
fix: install grant_summarizer package deps in CI to fix Python test failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,9 @@ jobs:
         python-version: "3.11"
 
     - name: Install Python deps
-      run: pip install -r requirements.txt
+      run: |
+        pip install -r requirements.txt
+        pip install -e grant_summarizer
 
     - name: Install JS deps
       run: npm ci


### PR DESCRIPTION
The pytest job was failing because requirements.txt doesn't include
pydantic, typer, pypdf, and cffi, which are declared in
grant_summarizer/pyproject.toml. Installing the package with -e
ensures all its dependencies are picked up automatically.

https://claude.ai/code/session_01G6VezJkgZGvNo5kP7qygaV