### PR TITLE
fix: install pytest before running Python tests in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install Python deps
       run: |
         pip install -r requirements.txt
+        pip install pytest
         pip install -e grant_summarizer
 
     - name: Install JS deps


### PR DESCRIPTION
pytest was not installed in the Python deps step, causing "command not
found" (exit 127) when the Run Python tests step executed.

https://claude.ai/code/session_01RuoQiy8re933j5gbiyejoU