### PR TITLE
Fix wrangler JSON parsing in CI workflow

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -73,36 +73,47 @@ jobs:
       # commands see the correct IDs without touching the committed file.
       - name: Provision Cloudflare resources
         run: |
+          # wrangler --json writes a banner to stdout before the JSON payload.
+          # json_from() strips everything before the first [ or { so jq gets
+          # clean input even when wrangler emits extra lines.
+          json_from() { sed -n '/^[[{]/,$ p'; }
+
           # ── USER_PROFILES KV ─────────────────────────────────────────────
           WORKER_NAME=$(grep '^name' wrangler.toml | head -1 | sed 's/name\s*=\s*"\(.*\)"/\1/')
           UP_ID=$(npx wrangler kv namespace list --json 2>/dev/null \
+            | json_from \
             | jq -r --arg t "${WORKER_NAME}-USER_PROFILES" '.[] | select(.title == $t) | .id' \
             | head -1)
           if [ -z "$UP_ID" ]; then
             echo "Creating USER_PROFILES KV namespace..."
             UP_ID=$(npx wrangler kv namespace create USER_PROFILES --json 2>/dev/null \
+              | json_from \
               | jq -r '.id')
           fi
           echo "USER_PROFILES id: $UP_ID"
 
           # ── LOGIN_ATTEMPTS KV ─────────────────────────────────────────────
           LA_ID=$(npx wrangler kv namespace list --json 2>/dev/null \
+            | json_from \
             | jq -r --arg t "${WORKER_NAME}-LOGIN_ATTEMPTS" '.[] | select(.title == $t) | .id' \
             | head -1)
           if [ -z "$LA_ID" ]; then
             echo "Creating LOGIN_ATTEMPTS KV namespace..."
             LA_ID=$(npx wrangler kv namespace create LOGIN_ATTEMPTS --json 2>/dev/null \
+              | json_from \
               | jq -r '.id')
           fi
           echo "LOGIN_ATTEMPTS id: $LA_ID"
 
           # ── EQORE_DB D1 ───────────────────────────────────────────────────
           DB_ID=$(npx wrangler d1 list --json 2>/dev/null \
+            | json_from \
             | jq -r '.[] | select(.name == "eqore-db") | .uuid' \
             | head -1)
           if [ -z "$DB_ID" ]; then
             echo "Creating eqore-db D1 database..."
             DB_ID=$(npx wrangler d1 create eqore-db --json 2>/dev/null \
+              | json_from \
               | jq -r '.uuid')
           fi
           echo "EQORE_DB id: $DB_ID"


### PR DESCRIPTION
## Summary
This PR fixes JSON parsing issues in the workers CI workflow by handling wrangler's banner output that precedes JSON payloads.

## Key Changes
- Added `json_from()` helper function that strips non-JSON content from wrangler's stdout before piping to jq
  - The function uses `sed` to skip everything before the first `[` or `{` character, ensuring jq receives clean JSON input
- Applied the helper to all `wrangler --json` command outputs:
  - `wrangler kv namespace list`
  - `wrangler kv namespace create`
  - `wrangler d1 list`
  - `wrangler d1 create`

## Implementation Details
The `json_from()` function uses `sed -n '/^[[{]/,$ p'` to:
1. Search for the first line starting with `[` or `{`
2. Print from that line to the end of input
3. Suppress all other output with the `-n` flag

This approach is robust and handles cases where wrangler emits informational banners or warnings before the JSON output, which was causing jq parsing failures in the resource provisioning step.

https://claude.ai/code/session_01RAwTNhb9MheGGdBobkfC6R