### PR TITLE
fix: suppress wrangler banner to prevent jq parse errors in CI

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -139,6 +139,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_NO_BANNER: "true"
 
       - name: Apply D1 migrations
         run: npx wrangler d1 migrations apply EQORE_DB --remote


### PR DESCRIPTION
The "Provision Cloudflare resources" step was failing with `jq: parse error: Invalid numeric literal at line 2, column 9` because wrangler's CLI banner was being printed to stdout even with the `json_from` stripping helper.\n\nFix: add `WRANGLER_NO_BANNER=true` to the step's env so wrangler never emits the banner, making the stdout output pure JSON.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGCKPS33YdCGuZABoxL6Ra)_