### PR TITLE
Add user sign-up and sign-in with D1 storage

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import Login from "./components/Login";
+import Signup from "./components/Signup";
 import Dashboard from "./components/Dashboard";
-import { checkAuth } from "./api";
+import { checkAuth, login } from "./api";
 
-type AuthState = "loading" | "unauthenticated" | "authenticated";
+type AuthState = "loading" | "unauthenticated" | "signup" | "authenticated";
 
 export default function App() {
   const [auth, setAuth] = useState<AuthState>("loading");
@@ -13,6 +14,16 @@ export default function App() {
       setAuth(ok ? "authenticated" : "unauthenticated");
     });
   }, []);
+
+  async function handleSignupSuccess(username: string, password: string) {
+    try {
+      await login(username, password);
+      setAuth("authenticated");
+    } catch {
+      // Auto-login failed after signup; fall back to login page
+      setAuth("unauthenticated");
+    }
+  }
 
   if (auth === "loading") {
     return (
@@ -25,8 +36,22 @@ export default function App() {
     );
   }
 
+  if (auth === "signup") {
+    return (
+      <Signup
+        onSuccess={(username, password) => handleSignupSuccess(username, password)}
+        onBackToLogin={() => setAuth("unauthenticated")}
+      />
+    );
+  }
+
   if (auth === "unauthenticated") {
-    return <Login onSuccess={() => setAuth("authenticated")} />;
+    return (
+      <Login
+        onSuccess={() => setAuth("authenticated")}
+        onSignUp={() => setAuth("signup")}
+      />
+    );
   }
 
   return <Dashboard onLogout={() => setAuth("unauthenticated")} />;

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -13,6 +13,18 @@ async function handleResponse<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+export async function signup(username: string, password: string, confirmPassword: string): Promise<void> {
+  const body = new URLSearchParams({ username, password, confirm_password: confirmPassword });
+  const res = await fetch(`${BASE}/signup`, {
+    method: "POST",
+    body,
+    credentials: "include",
+  });
+  if (res.ok) return;
+  const data = await res.json().catch(() => ({})) as { error?: string };
+  throw new Error(data.error || "Sign-up failed");
+}
+
 export async function login(username: string, password: string): Promise<void> {
   const body = new URLSearchParams({ username, password });
   const res = await fetch(`${BASE}/login`, {

--- a/ui/src/components/Signup.tsx
+++ b/ui/src/components/Signup.tsx
@@ -1,14 +1,15 @@
 import { useState, type FormEvent } from "react";
-import { login } from "../api";
+import { signup } from "../api";
 
 interface Props {
-  onSuccess: () => void;
-  onSignUp: () => void;
+  onSuccess: (username: string, password: string) => void;
+  onBackToLogin: () => void;
 }
 
-export default function Login({ onSuccess, onSignUp }: Props) {
+export default function Signup({ onSuccess, onBackToLogin }: Props) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -17,10 +18,10 @@ export default function Login({ onSuccess, onSignUp }: Props) {
     setError("");
     setLoading(true);
     try {
-      await login(username, password);
-      onSuccess();
+      await signup(username, password, confirmPassword);
+      onSuccess(username, password);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Login failed");
+      setError(err instanceof Error ? err.message : "Sign-up failed");
     } finally {
       setLoading(false);
     }
@@ -32,7 +33,7 @@ export default function Login({ onSuccess, onSignUp }: Props) {
         <div className="text-center mb-8">
           <div className="text-4xl mb-3">💰</div>
           <h1 className="text-2xl font-bold text-white">Grant Manager</h1>
-          <p className="text-gray-400 text-sm mt-1">Sign in to access your grant dashboard</p>
+          <p className="text-gray-400 text-sm mt-1">Create your account</p>
         </div>
 
         <form onSubmit={handleSubmit} className="card space-y-4">
@@ -51,6 +52,10 @@ export default function Login({ onSuccess, onSignUp }: Props) {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
+              minLength={3}
+              maxLength={32}
+              pattern="[a-zA-Z0-9_]+"
+              title="Letters, numbers, and underscores only"
             />
           </div>
 
@@ -59,9 +64,23 @@ export default function Login({ onSuccess, onSignUp }: Props) {
             <input
               className="input"
               type="password"
-              autoComplete="current-password"
+              autoComplete="new-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={6}
+            />
+            <p className="text-gray-500 text-xs mt-1">Minimum 6 characters</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">Confirm Password</label>
+            <input
+              className="input"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
               required
             />
           </div>
@@ -74,21 +93,21 @@ export default function Login({ onSuccess, onSignUp }: Props) {
             {loading ? (
               <>
                 <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                Signing in…
+                Creating account…
               </>
             ) : (
-              "Sign in"
+              "Create account"
             )}
           </button>
         </form>
 
         <p className="text-center text-gray-500 text-sm mt-4">
-          Don't have an account?{" "}
+          Already have an account?{" "}
           <button
-            onClick={onSignUp}
+            onClick={onBackToLogin}
             className="text-brand-400 hover:text-brand-300 underline"
           >
-            Create one
+            Sign in
           </button>
         </p>
       </div>

--- a/worker.js
+++ b/worker.js
@@ -142,6 +142,67 @@ export default {
 
     const users = { ...defaultUsers, ...envUsers };
 
+    if (url.pathname === "/signup" && request.method === "POST") {
+      const form = await request.formData();
+      const newUser = (form.get("username") || "").trim();
+      const newPass = form.get("password") || "";
+      const confirmPass = form.get("confirm_password") || "";
+
+      if (!newUser || newUser.length < 3 || newUser.length > 32) {
+        return new Response(JSON.stringify({ error: "Username must be 3–32 characters." }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (!/^[a-zA-Z0-9_]+$/.test(newUser)) {
+        return new Response(JSON.stringify({ error: "Username may only contain letters, numbers, and underscores." }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (!newPass || newPass.length < 6) {
+        return new Response(JSON.stringify({ error: "Password must be at least 6 characters." }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (newPass !== confirmPass) {
+        return new Response(JSON.stringify({ error: "Passwords do not match." }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      await env.GRANT_MANAGER_DB.prepare(
+        `CREATE TABLE IF NOT EXISTS users (
+          username TEXT PRIMARY KEY,
+          password_hash TEXT NOT NULL,
+          created_at INTEGER NOT NULL
+        )`
+      ).run();
+
+      const existing = await env.GRANT_MANAGER_DB.prepare(
+        "SELECT username FROM users WHERE username = ?"
+      ).bind(newUser).first();
+
+      if (existing || users[newUser]) {
+        return new Response(JSON.stringify({ error: "Username is already taken." }), {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      const hash = await hashPassword(newPass);
+      await env.GRANT_MANAGER_DB.prepare(
+        "INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, ?)"
+      ).bind(newUser, hash, Date.now()).run();
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
     if (url.pathname === "/login" && request.method === "POST") {
       const form = await request.formData();
       const user = form.get("username");
@@ -165,7 +226,23 @@ export default {
         return new Response("Too many attempts. Try again later.", { status: 429 });
       }
       const hashed = await hashPassword(pass || "");
-      if (users[user] && users[user] === hashed) {
+      let dbUser = null;
+      try {
+        await env.GRANT_MANAGER_DB.prepare(
+          `CREATE TABLE IF NOT EXISTS users (
+            username TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+          )`
+        ).run();
+        dbUser = await env.GRANT_MANAGER_DB.prepare(
+          "SELECT password_hash FROM users WHERE username = ?"
+        ).bind(user).first();
+      } catch (err) {
+        console.warn("D1 user lookup failed", err);
+      }
+      const dbMatch = dbUser && dbUser.password_hash === hashed;
+      if ((users[user] && users[user] === hashed) || dbMatch) {
         if (env.LOGIN_ATTEMPTS) {
           await env.LOGIN_ATTEMPTS.delete(ip);
         }


### PR DESCRIPTION
- Add POST /signup endpoint in worker.js that validates input and stores
  new user accounts (username + SHA-256 hashed password) in a D1 users
  table created on first use
- Update POST /login to also check D1 users table alongside the existing
  hardcoded/env users
- Add signup() API function in api.ts
- Add Signup.tsx React component with username/password/confirm form and
  link back to login
- Update Login.tsx with "Create account" link and onSignUp prop
- Update App.tsx to manage login/signup/authenticated view states and
  auto-login after successful sign-up

https://claude.ai/code/session_017bMu6jELsZLVwmXaL4ZFGw