### PR TITLE
Migrate UI rendering to static assets with SPA routing

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,3 @@
-import { renderDashboardPage } from "./ui/dashboard.js";
-import { renderLoginPage } from "./ui/login.js";
-import { renderTestEndpointsPage } from "./ui/test_endpoints.js";
 
 const MAX_ATTEMPTS = 5;
 const LOCKOUT_MS = 5 * 60 * 1000;
@@ -83,24 +80,6 @@ function rowMatchesQuery(row, query) {
   );
 }
 
-async function newSchemaPage(db) {
-  const columns = await getColumns(db);
-  const inputs = columns
-    .map((c) => `<label>${c} <input name="${c}" /></label><br />`)
-    .join("\n");
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="UTF-8"><title>New Schema Entry</title></head>
-<body>
-  <h1>Add Schema Entry</h1>
-  <form method="POST" action="/new_schema">
-    ${inputs}
-    <button type="submit">Save</button>
-  </form>
-  <p><a href="/dashboard">Back to dashboard</a></p>
-</body>
-</html>`;
-}
 
 const SESSION_TTL = 86400; // 24 hours in seconds
 
@@ -268,130 +247,7 @@ export default {
       return new Response("Unauthorized", { status: 401 });
     }
 
-    if (url.pathname === "/dashboard") {
-      if (!loggedIn) {
-        return new Response("", {
-          status: 302,
-          headers: { Location: "/" },
-        });
-      }
-      const columns = await getColumns(env.GRANT_MANAGER_DB);
-      let rows = [];
-      if (columns.length > 0) {
-        const { results } = await env.GRANT_MANAGER_DB.prepare(
-          `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
-        ).all();
-        records = results.map((r) =>
-          columns.reduce((acc, col) => {
-            acc[col] = r[col] ?? "";
-            return acc;
-          }, {})
-        );
-      }
-
-      const filtered = records.filter((r) => rowMatchesQuery(r, query));
-      const summary = computeSummary(filtered, columns);
-      const previewRows = filtered.slice(0, limit);
-
-      let profile = {};
-      let profileRaw = null;
-      if (env.USER_PROFILES) {
-        profileRaw = await env.USER_PROFILES.get(username);
-      } else {
-        console.warn("USER_PROFILES binding is not configured");
-      }
-      if (profileRaw) {
-        try {
-          profile = JSON.parse(profileRaw);
-        } catch {
-          profile = {};
-        }
-      }
-
-      return new Response(
-        renderDashboardPage({
-          username,
-          headers: columns,
-          previewRows,
-          query,
-          limit,
-          totalRows: filtered.length,
-          summary,
-          datasetLabel,
-          sourceLabel,
-          profile,
-        }),
-        {
-          headers: { "content-type": "text/html; charset=UTF-8" },
-        }
-      );
-    }
-
-      if (url.pathname === "/test-endpoints") {
-        if (!loggedIn) {
-          return new Response("", {
-            status: 302,
-            headers: { Location: "/" },
-          });
-        }
-        return new Response(renderTestEndpointsPage(username), {
-          headers: { "content-type": "text/html; charset=UTF-8" },
-        });
-      }
-
-    if (url.pathname === "/new_schema") {
-      if (!loggedIn) {
-        return new Response("", {
-          status: 302,
-          headers: { Location: "/" },
-        });
-      }
-      if (request.method === "POST") {
-        const columns = await getColumns(env.GRANT_MANAGER_DB);
-        const form = await request.formData();
-        const values = columns.map((c) => form.get(c) || "");
-        const placeholders = columns.map(() => "?").join(",");
-        const cols = columns.map((c) => `"${c}"`).join(",");
-        await env.GRANT_MANAGER_DB.prepare(
-          `INSERT OR REPLACE INTO programs (${cols}) VALUES (${placeholders})`
-        )
-          .bind(...values)
-          .run();
-        return new Response("", {
-          status: 302,
-          headers: { Location: "/dashboard" },
-        });
-      }
-      return new Response(await newSchemaPage(env.GRANT_MANAGER_DB), {
-        headers: { "content-type": "text/html; charset=UTF-8" },
-      });
-    }
-
-    if (url.pathname === "/schema") {
-      const columns = await getColumns(env.GRANT_MANAGER_DB);
-      return new Response(JSON.stringify(columns), {
-        headers: { "content-type": "application/json" },
-      });
-    }
-
-    if (url.pathname === "/data") {
-      const columns = await getColumns(env.GRANT_MANAGER_DB);
-      let body = "";
-      if (columns.length > 0) {
-        const { results } = await env.GRANT_MANAGER_DB.prepare(
-          `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
-        ).all();
-        body = [
-          columns.join(","),
-          ...results.map((r) => columns.map((c) => r[c] ?? "").join(",")),
-        ].join("\n");
-      }
-      return new Response(body, {
-        headers: { "content-type": "text/csv; charset=UTF-8" },
-      });
-    }
-
-    if (url.pathname === "/api/grants") {
+if (url.pathname === "/api/grants") {
       if (!loggedIn) {
         return new Response("Unauthorized", { status: 401 });
       }
@@ -473,13 +329,7 @@ export default {
       });
     }
 
-    if (url.pathname === "/" && loggedIn) {
-      return new Response("", { status: 302, headers: { Location: "/dashboard" } });
-    }
-
-    return new Response(renderLoginPage(), {
-      headers: { "content-type": "text/html; charset=UTF-8" },
-    });
+    return env.ASSETS.fetch(request);
   },
 };
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ workers_dev = true
 [build]
 command = "cd ui && npm install && npm run build"
 
-assets = { directory = "ui/dist", not_found_handling = "single-page-application" }
+assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
 
 [[kv_namespaces]]
 binding = "USER_PROFILES"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,10 +3,10 @@ main = "worker.js"
 compatibility_date = "2024-05-29"
 workers_dev = true
 
+assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
+
 [build]
 command = "cd ui && npm install && npm run build"
-
-assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
 
 [[kv_namespaces]]
 binding = "USER_PROFILES"


### PR DESCRIPTION
## Summary
This PR refactors the application to serve the UI as static assets from a built distribution directory instead of server-side rendering HTML pages. The worker now delegates all non-API requests to the static asset handler, enabling a single-page application (SPA) architecture.

## Key Changes
- **Removed server-side rendering imports**: Deleted imports for `renderDashboardPage`, `renderLoginPage`, and `renderTestEndpointsPage` functions
- **Removed page rendering logic**: Eliminated route handlers for `/dashboard`, `/test-endpoints`, `/new_schema`, `/schema`, `/data`, and the login page fallback
- **Removed HTML generation function**: Deleted `newSchemaPage()` function that dynamically generated form HTML
- **Added static asset serving**: Replaced all UI route handlers with a single fallback that delegates to `env.ASSETS.fetch(request)` for serving pre-built static files
- **Updated wrangler.toml**: Added `binding = "ASSETS"` to the assets configuration to expose the static asset handler to the worker

## Implementation Details
- The worker now focuses solely on API endpoints (`/api/grants`) and authentication logic
- All UI pages are now served from the `ui/dist` directory as pre-built static assets
- The SPA routing is configured with `not_found_handling = "single-page-application"` to handle client-side routing
- This change requires the UI to be built separately via the `npm run build` command defined in the build configuration

https://claude.ai/code/session_01NXk2qFKJFwTPBMW3bUhv2T