### PR TITLE
Add user profile matching and live per-user grant scoring

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,26 +2,43 @@ import { useEffect, useState } from "react";
 import Login from "./components/Login";
 import Signup from "./components/Signup";
 import Dashboard from "./components/Dashboard";
-import { checkAuth, login } from "./api";
+import ProfileSetup from "./components/ProfileSetup";
+import { checkAuth, login, fetchProfile, saveProfile } from "./api";
+import type { UserProfile } from "./api";
 
-type AuthState = "loading" | "unauthenticated" | "signup" | "authenticated";
+type AuthState = "loading" | "unauthenticated" | "signup" | "profile-setup" | "authenticated";
 
 export default function App() {
   const [auth, setAuth] = useState<AuthState>("loading");
+  const [profileSaving, setProfileSaving] = useState(false);
 
   useEffect(() => {
-    checkAuth().then((ok) => {
-      setAuth(ok ? "authenticated" : "unauthenticated");
+    checkAuth().then(async (ok) => {
+      if (!ok) { setAuth("unauthenticated"); return; }
+      const profile = await fetchProfile().catch(() => null);
+      setAuth(profile ? "authenticated" : "profile-setup");
     });
   }, []);
 
   async function handleSignupSuccess(username: string, password: string) {
     try {
       await login(username, password);
+      setAuth("profile-setup");
+    } catch {
+      setAuth("unauthenticated");
+    }
+  }
+
+  async function handleProfileSave(profile: UserProfile) {
+    setProfileSaving(true);
+    try {
+      await saveProfile(profile);
       setAuth("authenticated");
     } catch {
-      // Auto-login failed after signup; fall back to login page
-      setAuth("unauthenticated");
+      // proceed anyway
+      setAuth("authenticated");
+    } finally {
+      setProfileSaving(false);
     }
   }
 
@@ -48,8 +65,21 @@ export default function App() {
   if (auth === "unauthenticated") {
     return (
       <Login
-        onSuccess={() => setAuth("authenticated")}
+        onSuccess={async () => {
+          const profile = await fetchProfile().catch(() => null);
+          setAuth(profile ? "authenticated" : "profile-setup");
+        }}
         onSignUp={() => setAuth("signup")}
+      />
+    );
+  }
+
+  if (auth === "profile-setup") {
+    return (
+      <ProfileSetup
+        onSave={handleProfileSave}
+        onSkip={() => setAuth("authenticated")}
+        saving={profileSaving}
       />
     );
   }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -140,6 +140,28 @@ export async function exportCsv(): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
+export interface UserProfile {
+  focusAreas: string[];
+  orgType: string;
+  stage: string;
+}
+
+export async function fetchProfile(): Promise<UserProfile | null> {
+  const res = await fetch(`${BASE}/api/profile`, { credentials: "include" });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function saveProfile(profile: UserProfile): Promise<void> {
+  const res = await fetch(`${BASE}/api/profile`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(profile),
+  });
+  if (!res.ok) throw new Error("Failed to save profile");
+}
+
 export async function checkAuth(): Promise<boolean> {
   try {
     const res = await fetch(`${BASE}/api/grants`, {

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import type { Grant, FilterState } from "../types";
-import { fetchGrants, logout, exportCsv } from "../api";
+import { fetchGrants, logout, exportCsv, fetchProfile, saveProfile } from "../api";
+import type { UserProfile } from "../api";
 import SummaryCards from "./SummaryCards";
 import GrantTable from "./GrantTable";
 import GrantDrawer from "./GrantDrawer";
 import ChatPanel from "./ChatPanel";
+import ProfileSetup from "./ProfileSetup";
 
 const WATCHLIST_KEY = "gm_watchlist";
 const CANDIDATES_KEY = "gm_candidates";
@@ -42,6 +44,9 @@ export default function Dashboard({ onLogout }: Props) {
   const [filters, setFilters] = useState<FilterState>(INITIAL_FILTERS);
   const [selectedGrant, setSelectedGrant] = useState<Grant | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profileSaving, setProfileSaving] = useState(false);
 
   const [watchlist, setWatchlist] = useState<Set<string>>(() => loadSet(WATCHLIST_KEY));
   const [candidates, setCandidates] = useState<Set<string>>(() => loadSet(CANDIDATES_KEY));
@@ -57,7 +62,26 @@ export default function Dashboard({ onLogout }: Props) {
         }
       })
       .finally(() => setLoading(false));
+    fetchProfile().then(setProfile).catch(() => {});
   }, [onLogout]);
+
+  async function handleProfileSave(p: UserProfile) {
+    setProfileSaving(true);
+    try {
+      await saveProfile(p);
+      setProfile(p);
+      setProfileOpen(false);
+      // Reload grants with new profile scoring
+      setLoading(true);
+      const updated = await fetchGrants();
+      setGrants(updated);
+    } catch {
+      // ignore
+    } finally {
+      setProfileSaving(false);
+      setLoading(false);
+    }
+  }
 
   const handleLogout = useCallback(async () => {
     await logout().catch(() => {});
@@ -118,6 +142,18 @@ export default function Dashboard({ onLogout }: Props) {
         </div>
 
         <div className="flex items-center gap-2">
+          <button
+            onClick={() => setProfileOpen(true)}
+            className="btn-ghost px-2.5 gap-1.5 hidden sm:flex"
+            title="Edit profile"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            <span className="text-xs">{profile ? "Profile" : "Set profile"}</span>
+            {!profile && <span className="w-1.5 h-1.5 rounded-full bg-brand-400" />}
+          </button>
+
           <button
             onClick={handleExport}
             className="btn-outline hidden sm:flex gap-1.5"
@@ -292,6 +328,20 @@ export default function Dashboard({ onLogout }: Props) {
 
       {/* Chat panel */}
       <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} />
+
+      {/* Profile modal */}
+      {profileOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto">
+            <ProfileSetup
+              initial={profile}
+              onSave={handleProfileSave}
+              onSkip={() => setProfileOpen(false)}
+              saving={profileSaving}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/components/GrantDrawer.tsx
+++ b/ui/src/components/GrantDrawer.tsx
@@ -142,7 +142,7 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated }: Props) {
                   >
                     <p className="text-gray-500 text-xs font-medium mb-1">{col as string}</p>
                     {isScoreCol(col) ? (
-                      <ScoreBadge value={grant[col]} />
+                      <ScoreBadge value={grant[col] ?? ""} />
                     ) : (
                       <p className="text-gray-200 text-sm leading-snug">
                         {String(grant[col] || "—")}

--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -76,7 +76,7 @@ export default function GrantTable({
   onToggleCandidate,
 }: Props) {
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "Weighted Score", desc: true },
+    { id: "score", desc: true },
   ]);
 
   const filtered = useMemo(() => {
@@ -84,7 +84,7 @@ export default function GrantTable({
       if (filters.type && g.Type !== filters.type) return false;
       if (filters.stage && g.Stage !== filters.stage) return false;
       if (filters.minScore) {
-        const score = parseFloat(String(g["Weighted Score"] || "0"));
+        const score = parseFloat(String(g.score ?? g["Weighted Score"] ?? "0"));
         if (score < parseFloat(filters.minScore)) return false;
       }
       if (filters.deadlineBefore) {
@@ -168,13 +168,13 @@ export default function GrantTable({
         cell: (info) => <ScoreCell value={info.getValue()} />,
         size: 55,
       }),
-      columnHelper.accessor("Weighted Score", {
-        header: "Score",
-        cell: (info) => <ScoreCell value={info.getValue()} />,
-        size: 60,
+      columnHelper.accessor("score", {
+        header: "Match",
+        cell: (info) => <ScoreCell value={info.getValue() ?? 0} />,
+        size: 65,
         sortingFn: (a, b) => {
-          const sa = parseFloat(String(a.original["Weighted Score"] || "0"));
-          const sb = parseFloat(String(b.original["Weighted Score"] || "0"));
+          const sa = parseFloat(String(a.original.score ?? "0"));
+          const sb = parseFloat(String(b.original.score ?? "0"));
           return sa - sb;
         },
       }),

--- a/ui/src/components/ProfileSetup.tsx
+++ b/ui/src/components/ProfileSetup.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import type { UserProfile } from "../api";
+
+const FOCUS_AREAS = [
+  "Health & Medicine",
+  "Education & Workforce",
+  "Technology & Innovation",
+  "Housing & Community",
+  "Environment & Climate",
+  "Agriculture & Food",
+  "Social Services",
+  "Arts & Humanities",
+  "International Development",
+  "Veterans & Military",
+  "Research & Science",
+  "Justice & Safety",
+];
+
+const ORG_TYPES = [
+  { value: "nonprofit", label: "Nonprofit / NGO" },
+  { value: "university", label: "University / Research Institution" },
+  { value: "startup", label: "Startup / Small Business" },
+  { value: "government", label: "Government / Tribal" },
+  { value: "individual", label: "Individual Researcher" },
+  { value: "hospital", label: "Hospital / Health System" },
+];
+
+const STAGES = [
+  { value: "research", label: "Early Research / Ideation" },
+  { value: "pilot", label: "Pilot / Proof of Concept" },
+  { value: "growth", label: "Growth / Scaling" },
+  { value: "established", label: "Established Program" },
+];
+
+interface Props {
+  initial?: UserProfile | null;
+  onSave: (profile: UserProfile) => void;
+  onSkip?: () => void;
+  saving?: boolean;
+}
+
+export default function ProfileSetup({ initial, onSave, onSkip, saving }: Props) {
+  const [focusAreas, setFocusAreas] = useState<string[]>(initial?.focusAreas ?? []);
+  const [orgType, setOrgType] = useState(initial?.orgType ?? "");
+  const [stage, setStage] = useState(initial?.stage ?? "");
+
+  function toggleFocus(area: string) {
+    setFocusAreas((prev) =>
+      prev.includes(area) ? prev.filter((a) => a !== area) : [...prev, area]
+    );
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    onSave({ focusAreas, orgType, stage });
+  }
+
+  const isValid = focusAreas.length > 0 && orgType && stage;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-950 p-4">
+      <div className="w-full max-w-lg">
+        <div className="text-center mb-8">
+          <div className="text-4xl mb-3">🎯</div>
+          <h1 className="text-2xl font-bold text-white">Set up your profile</h1>
+          <p className="text-gray-400 text-sm mt-1">
+            Help us match grants to your specific context
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="card space-y-6">
+          {/* Focus areas */}
+          <div>
+            <label className="block text-sm font-semibold text-white mb-3">
+              Focus areas
+              <span className="ml-1 text-gray-500 font-normal">(select all that apply)</span>
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {FOCUS_AREAS.map((area) => {
+                const active = focusAreas.includes(area);
+                return (
+                  <button
+                    key={area}
+                    type="button"
+                    onClick={() => toggleFocus(area)}
+                    className={`text-left px-3 py-2 rounded-lg text-sm border transition-colors ${
+                      active
+                        ? "bg-brand-600/30 border-brand-500 text-brand-300"
+                        : "bg-gray-800 border-gray-700 text-gray-400 hover:border-gray-600 hover:text-gray-300"
+                    }`}
+                  >
+                    {area}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Org type */}
+          <div>
+            <label className="block text-sm font-semibold text-white mb-3">
+              Organization type
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {ORG_TYPES.map(({ value, label }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setOrgType(value)}
+                  className={`text-left px-3 py-2 rounded-lg text-sm border transition-colors ${
+                    orgType === value
+                      ? "bg-brand-600/30 border-brand-500 text-brand-300"
+                      : "bg-gray-800 border-gray-700 text-gray-400 hover:border-gray-600 hover:text-gray-300"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Stage */}
+          <div>
+            <label className="block text-sm font-semibold text-white mb-3">
+              Current stage
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {STAGES.map(({ value, label }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setStage(value)}
+                  className={`text-left px-3 py-2 rounded-lg text-sm border transition-colors ${
+                    stage === value
+                      ? "bg-brand-600/30 border-brand-500 text-brand-300"
+                      : "bg-gray-800 border-gray-700 text-gray-400 hover:border-gray-600 hover:text-gray-300"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="submit"
+              disabled={!isValid || saving}
+              className="btn-primary flex-1 justify-center py-2.5"
+            >
+              {saving ? (
+                <>
+                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                "Save profile & find matches"
+              )}
+            </button>
+            {onSkip && (
+              <button
+                type="button"
+                onClick={onSkip}
+                className="btn-ghost px-4"
+              >
+                Skip
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -16,7 +16,8 @@ export interface Grant {
   Ease: number | string;
   "Weighted Score": number | string;
   "Notes/Actions": string;
-  [key: string]: string | number;
+  score?: number;
+  [key: string]: string | number | undefined;
 }
 
 export type SortDir = "asc" | "desc" | false;

--- a/worker.js
+++ b/worker.js
@@ -247,25 +247,44 @@ export default {
       return new Response("Unauthorized", { status: 401 });
     }
 
-if (url.pathname === "/api/grants") {
+if (url.pathname === "/api/profile") {
+      if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+      if (request.method === "GET") {
+        const raw = env.USER_PROFILES ? await env.USER_PROFILES.get(`profile:${username}`) : null;
+        const profile = raw ? JSON.parse(raw) : null;
+        return new Response(JSON.stringify(profile), { headers: { "content-type": "application/json" } });
+      }
+      if (request.method === "POST") {
+        const body = await request.json();
+        await env.USER_PROFILES.put(`profile:${username}`, JSON.stringify(body));
+        return new Response(JSON.stringify({ ok: true }), { headers: { "content-type": "application/json" } });
+      }
+    }
+
+    if (url.pathname === "/api/grants") {
       if (!loggedIn) {
         return new Response("Unauthorized", { status: 401 });
       }
-      let profileRaw = null;
-      if (env.USER_PROFILES) {
-        profileRaw = await env.USER_PROFILES.get(username);
-      } else {
-        console.warn("USER_PROFILES binding is not configured");
-        return new Response("USER_PROFILES binding not configured", { status: 500 });
-      }
       let profile = {};
-      if (profileRaw) {
-        try {
-          profile = JSON.parse(profileRaw);
-        } catch (err) {
-          profile = {};
+      if (env.USER_PROFILES) {
+        const raw = await env.USER_PROFILES.get(`profile:${username}`);
+        if (raw) {
+          try { profile = JSON.parse(raw); } catch { profile = {}; }
         }
       }
+
+      // Keywords derived from user profile for text matching
+      const focusAreas = profile.focusAreas || [];
+      const orgType = profile.orgType || "";
+      const stage = profile.stage || "";
+
+      // Build a keyword set from profile for matching against grant text
+      const keywords = [
+        ...focusAreas.map(f => f.toLowerCase()),
+        orgType.toLowerCase(),
+        stage.toLowerCase(),
+      ].filter(Boolean);
+
       const columns = await getColumns(env.GRANT_MANAGER_DB);
       let results = [];
       if (columns.length > 0) {
@@ -274,12 +293,39 @@ if (url.pathname === "/api/grants") {
         ).all();
         results = rows
           .map((r) => {
-            let score = 0;
-            for (const [field, weight] of Object.entries(profile)) {
-              const val = Number(r[field]) || 0;
-              score += val * Number(weight);
+            // Combine searchable text fields from the grant
+            const grantText = [r.Name, r.Sponsor, r["Eligibility (key conditions)"], r.Benefits, r["Notes/Actions"]]
+              .join(" ").toLowerCase();
+
+            // Keyword overlap score (0–5 points)
+            let keywordScore = 0;
+            for (const kw of keywords) {
+              if (kw && grantText.includes(kw)) keywordScore += 1;
             }
-            return { ...r, score };
+
+            // Curator numeric scores (0–5 scale from data)
+            const relevance = parseFloat(r.Relevance) || 0;
+            const fit = parseFloat(r.Fit) || 0;
+            const ease = parseFloat(r.Ease) || 0;
+            const curatorScore = (relevance + fit + ease) / 3;
+
+            // Deadline recency bonus (sooner = higher, within 1 year)
+            let recency = 0;
+            const deadline = r["Deadline/Next Cohort"] ? new Date(r["Deadline/Next Cohort"]) : null;
+            if (deadline && !isNaN(deadline.getTime())) {
+              const daysUntil = (deadline - Date.now()) / 86400000;
+              if (daysUntil >= 0 && daysUntil <= 365) recency = 1 - daysUntil / 365;
+            }
+
+            // Weighted composite: keyword match weighted heavily when profile exists
+            const hasProfile = keywords.length > 0;
+            const score = hasProfile
+              ? (keywordScore / Math.max(keywords.length, 1)) * 5 * 0.5
+                + curatorScore * 0.35
+                + recency * 0.15
+              : curatorScore * 0.85 + recency * 0.15;
+
+            return { ...r, score: Math.round(score * 100) / 100 };
           })
           .sort((a, b) => b.score - a.score);
       }


### PR DESCRIPTION
## Summary

- **Profile setup UI** — new `ProfileSetup` component shown after first login; collects focus areas (Health, Education, Tech, Housing, etc.), org type (nonprofit/university/startup/etc.), and stage. Accessible anytime via a Profile button in the dashboard header.
- **`/api/profile` GET/POST endpoint** — reads/writes each user's profile to Cloudflare KV under `profile:<username>`
- **Live per-user scoring** — replaces static `Weighted Score` with a computed `score` per request: 50% keyword overlap between user profile and grant text, 35% curator scores, 15% deadline urgency. Falls back to curator + recency when no profile is set.
- **GrantTable** now sorts by the live `score` field ("Match" column) instead of the static DB column

## Test plan

- [ ] New user signup → profile setup screen appears
- [ ] Select focus areas, org type, stage → save → redirected to dashboard with grants ranked by match score
- [ ] Profile button in header → edit profile → grants re-rank on save
- [ ] Two users with different profiles see different grant rankings
- [ ] User with no profile set still sees grants (fallback scoring)
- [ ] Min score filter applies to the live match score

https://claude.ai/code/session_01Nx4yeMdPZnrL3TarvtzRiq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nx4yeMdPZnrL3TarvtzRiq)_