### PR TITLE
Add welcome page with profile summary and personalized match banner

### DIFF
--- a/functions/[[catchall]].js
+++ b/functions/[[catchall]].js
@@ -254,6 +254,14 @@ export async function onRequest(context) {
     });
   }
 
+  // API: me
+  if (url.pathname === "/api/me") {
+    if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+    return new Response(JSON.stringify({ username }), {
+      headers: { "content-type": "application/json" },
+    });
+  }
+
   // API: health
   if (url.pathname === "/api/health") {
     return new Response(JSON.stringify({ ok: true }), {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,40 +3,72 @@ import Login from "./components/Login";
 import Signup from "./components/Signup";
 import Dashboard from "./components/Dashboard";
 import ProfileSetup from "./components/ProfileSetup";
-import { checkAuth, login, fetchProfile, saveProfile } from "./api";
+import WelcomePage from "./components/WelcomePage";
+import { checkAuth, login, fetchProfile, saveProfile, fetchMe } from "./api";
 import type { UserProfile } from "./api";
 
-type AuthState = "loading" | "unauthenticated" | "signup" | "profile-setup" | "authenticated";
+type AuthState = "loading" | "unauthenticated" | "signup" | "profile-setup" | "welcome" | "authenticated";
 
 export default function App() {
   const [auth, setAuth] = useState<AuthState>("loading");
   const [profileSaving, setProfileSaving] = useState(false);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [username, setUsername] = useState("");
 
   useEffect(() => {
     checkAuth().then(async (ok) => {
       if (!ok) { setAuth("unauthenticated"); return; }
-      const profile = await fetchProfile().catch(() => null);
-      setAuth(profile ? "authenticated" : "profile-setup");
+      const [p, me] = await Promise.all([
+        fetchProfile().catch(() => null),
+        fetchMe(),
+      ]);
+      setProfile(p);
+      setUsername(me ?? "");
+      setAuth(p ? "welcome" : "profile-setup");
     });
   }, []);
 
-  async function handleSignupSuccess(username: string, password: string) {
+  async function handleSignupSuccess(user: string, password: string) {
     try {
-      await login(username, password);
+      await login(user, password);
+      setUsername(user);
       setAuth("profile-setup");
     } catch {
       setAuth("unauthenticated");
     }
   }
 
-  async function handleProfileSave(profile: UserProfile) {
+  async function handleLoginSuccess() {
+    const [p, me] = await Promise.all([
+      fetchProfile().catch(() => null),
+      fetchMe(),
+    ]);
+    setProfile(p);
+    setUsername(me ?? "");
+    setAuth(p ? "welcome" : "profile-setup");
+  }
+
+  async function handleProfileSave(p: UserProfile) {
     setProfileSaving(true);
     try {
-      await saveProfile(profile);
-      setAuth("authenticated");
+      await saveProfile(p);
+      setProfile(p);
+      setAuth("welcome");
     } catch {
-      // proceed anyway
-      setAuth("authenticated");
+      setProfile(p);
+      setAuth("welcome");
+    } finally {
+      setProfileSaving(false);
+    }
+  }
+
+  async function handleWelcomeProfileSave(p: UserProfile) {
+    setProfileSaving(true);
+    try {
+      await saveProfile(p);
+      setProfile(p);
+    } catch {
+      setProfile(p);
     } finally {
       setProfileSaving(false);
     }
@@ -56,7 +88,7 @@ export default function App() {
   if (auth === "signup") {
     return (
       <Signup
-        onSuccess={(username, password) => handleSignupSuccess(username, password)}
+        onSuccess={(user, password) => handleSignupSuccess(user, password)}
         onBackToLogin={() => setAuth("unauthenticated")}
       />
     );
@@ -65,10 +97,7 @@ export default function App() {
   if (auth === "unauthenticated") {
     return (
       <Login
-        onSuccess={async () => {
-          const profile = await fetchProfile().catch(() => null);
-          setAuth(profile ? "authenticated" : "profile-setup");
-        }}
+        onSuccess={handleLoginSuccess}
         onSignUp={() => setAuth("signup")}
       />
     );
@@ -77,6 +106,7 @@ export default function App() {
   if (auth === "profile-setup") {
     return (
       <ProfileSetup
+        initial={profile}
         onSave={handleProfileSave}
         onSkip={() => setAuth("authenticated")}
         saving={profileSaving}
@@ -84,5 +114,22 @@ export default function App() {
     );
   }
 
-  return <Dashboard onLogout={() => setAuth("unauthenticated")} />;
+  if (auth === "welcome" && profile) {
+    return (
+      <WelcomePage
+        username={username || "there"}
+        profile={profile}
+        onViewMatches={() => setAuth("authenticated")}
+        onSaveProfile={handleWelcomeProfileSave}
+        saving={profileSaving}
+      />
+    );
+  }
+
+  return (
+    <Dashboard
+      onLogout={() => setAuth("unauthenticated")}
+      onBackToProfile={profile ? () => setAuth("welcome") : undefined}
+    />
+  );
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -162,6 +162,17 @@ export async function saveProfile(profile: UserProfile): Promise<void> {
   if (!res.ok) throw new Error("Failed to save profile");
 }
 
+export async function fetchMe(): Promise<string | null> {
+  try {
+    const res = await fetch(`${BASE}/api/me`, { credentials: "include" });
+    if (!res.ok) return null;
+    const data = await res.json() as { username: string };
+    return data.username ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function checkAuth(): Promise<boolean> {
   try {
     const res = await fetch(`${BASE}/api/grants`, {

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -26,6 +26,7 @@ function saveSet(key: string, s: Set<string>) {
 
 interface Props {
   onLogout: () => void;
+  onBackToProfile?: () => void;
 }
 
 const INITIAL_FILTERS: FilterState = {
@@ -36,7 +37,7 @@ const INITIAL_FILTERS: FilterState = {
   search: "",
 };
 
-export default function Dashboard({ onLogout }: Props) {
+export default function Dashboard({ onLogout, onBackToProfile }: Props) {
   const [grants, setGrants] = useState<Grant[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -142,17 +143,19 @@ export default function Dashboard({ onLogout }: Props) {
         </div>
 
         <div className="flex items-center gap-2">
-          <button
-            onClick={() => setProfileOpen(true)}
-            className="btn-ghost px-2.5 gap-1.5 hidden sm:flex"
-            title="Edit profile"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-            <span className="text-xs">{profile ? "Profile" : "Set profile"}</span>
-            {!profile && <span className="w-1.5 h-1.5 rounded-full bg-brand-400" />}
-          </button>
+          {onBackToProfile && (
+            <button
+              onClick={onBackToProfile}
+              className="btn-ghost px-2.5 gap-1.5 hidden sm:flex"
+              title="Back to profile"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              <span className="text-xs">{profile ? "My Profile" : "Set profile"}</span>
+              {!profile && <span className="w-1.5 h-1.5 rounded-full bg-brand-400" />}
+            </button>
+          )}
 
           <button
             onClick={handleExport}
@@ -206,6 +209,14 @@ export default function Dashboard({ onLogout }: Props) {
 
         {!loading && !error && (
           <>
+            {profile && (
+              <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl bg-brand-900/20 border border-brand-800/40 text-sm text-brand-300">
+                <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                </svg>
+                <span>Grants are sorted by <strong>personalized match score</strong> based on your profile — check the Match column.</span>
+              </div>
+            )}
             <SummaryCards grants={grants} />
 
             {/* Filters */}

--- a/ui/src/components/WelcomePage.tsx
+++ b/ui/src/components/WelcomePage.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import type { UserProfile } from "../api";
+import ProfileSetup from "./ProfileSetup";
+
+const FOCUS_LABEL: Record<string, string> = {
+  "Health & Medicine": "Health & Medicine",
+  "Education & Workforce": "Education & Workforce",
+  "Technology & Innovation": "Technology & Innovation",
+  "Housing & Community": "Housing & Community",
+  "Environment & Climate": "Environment & Climate",
+  "Agriculture & Food": "Agriculture & Food",
+  "Social Services": "Social Services",
+  "Arts & Humanities": "Arts & Humanities",
+  "International Development": "International Development",
+  "Veterans & Military": "Veterans & Military",
+  "Research & Science": "Research & Science",
+  "Justice & Safety": "Justice & Safety",
+};
+
+const ORG_LABEL: Record<string, string> = {
+  nonprofit: "Nonprofit / NGO",
+  university: "University / Research Institution",
+  startup: "Startup / Small Business",
+  government: "Government / Tribal",
+  individual: "Individual Researcher",
+  hospital: "Hospital / Health System",
+};
+
+const STAGE_LABEL: Record<string, string> = {
+  research: "Early Research / Ideation",
+  pilot: "Pilot / Proof of Concept",
+  growth: "Growth / Scaling",
+  established: "Established Program",
+};
+
+interface Props {
+  username: string;
+  profile: UserProfile;
+  onViewMatches: () => void;
+  onSaveProfile: (p: UserProfile) => Promise<void>;
+  saving: boolean;
+}
+
+export default function WelcomePage({ username, profile, onViewMatches, onSaveProfile, saving }: Props) {
+  const [editing, setEditing] = useState(false);
+
+  async function handleSave(p: UserProfile) {
+    await onSaveProfile(p);
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <div className="min-h-screen bg-gray-950 p-4 flex items-start justify-center pt-10">
+        <div className="w-full max-w-lg">
+          <button
+            onClick={() => setEditing(false)}
+            className="text-gray-400 hover:text-white text-sm mb-4 flex items-center gap-1"
+          >
+            ← Back
+          </button>
+          <ProfileSetup initial={profile} onSave={handleSave} saving={saving} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 flex flex-col items-center justify-center p-4">
+      <div className="w-full max-w-lg space-y-6">
+
+        {/* Welcome header */}
+        <div className="text-center">
+          <div className="text-5xl mb-4">💰</div>
+          <h1 className="text-3xl font-bold text-white">Welcome back, {username}!</h1>
+          <p className="text-gray-400 mt-2">Your grant matches are ready based on your profile.</p>
+        </div>
+
+        {/* Profile summary card */}
+        <div className="card space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-white uppercase tracking-wide">Your Profile</h2>
+            <button
+              onClick={() => setEditing(true)}
+              className="text-xs text-brand-400 hover:text-brand-300 transition-colors"
+            >
+              Edit parameters
+            </button>
+          </div>
+
+          {/* Focus areas */}
+          <div>
+            <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Focus Areas</p>
+            <div className="flex flex-wrap gap-2">
+              {profile.focusAreas.length > 0 ? profile.focusAreas.map((area) => (
+                <span key={area} className="badge bg-brand-600/20 text-brand-300 border border-brand-700/50">
+                  {FOCUS_LABEL[area] ?? area}
+                </span>
+              )) : <span className="text-gray-500 text-sm">None selected</span>}
+            </div>
+          </div>
+
+          {/* Org type & Stage */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Organization</p>
+              <p className="text-sm text-gray-300">{(ORG_LABEL[profile.orgType] ?? profile.orgType) || "—"}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Stage</p>
+              <p className="text-sm text-gray-300">{(STAGE_LABEL[profile.stage] ?? profile.stage) || "—"}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <button
+          onClick={onViewMatches}
+          className="btn-primary w-full justify-center py-3 text-base"
+        >
+          View my personalized grant matches →
+        </button>
+
+      </div>
+    </div>
+  );
+}

--- a/worker.js
+++ b/worker.js
@@ -334,6 +334,13 @@ if (url.pathname === "/api/profile") {
       });
     }
 
+    if (url.pathname === "/api/me") {
+      if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+      return new Response(JSON.stringify({ username }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
     if (url.pathname === "/api/health") {
       return new Response(JSON.stringify({ ok: true }), {
         headers: { "content-type": "application/json" },


### PR DESCRIPTION
After login, users now land on a welcome screen showing their username, profile selections (focus areas, org type, stage), and an "Edit parameters" option before viewing grants. The grants dashboard shows a banner indicating scores are personalized. Adds /api/me endpoint and fetchMe() to surface the logged-in username on the frontend.

https://claude.ai/code/session_011CBTQ7ZaRosRkoQu4oDzzM