### PR TITLE
Fix match score consistency: summary card and table now use same score

### DIFF
--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -22,13 +22,14 @@ interface Props {
 
 const columnHelper = createColumnHelper<Grant>();
 
-function ScoreCell({ value }: { value: string | number }) {
+function ScoreCell({ value, max = 5 }: { value: string | number; max?: number }) {
   const n = parseFloat(String(value));
   if (isNaN(n)) return <span className="text-gray-500">—</span>;
+  const pct = n / max;
   const color =
-    n >= 7
+    pct >= 0.65
       ? "text-green-400"
-      : n >= 4
+      : pct >= 0.35
         ? "text-yellow-400"
         : "text-red-400";
   return <span className={`font-semibold ${color}`}>{n.toFixed(1)}</span>;
@@ -155,22 +156,22 @@ export default function GrantTable({
       }),
       columnHelper.accessor("Relevance", {
         header: "Rel",
-        cell: (info) => <ScoreCell value={info.getValue()} />,
+        cell: (info) => <ScoreCell value={info.getValue()} max={10} />,
         size: 55,
       }),
       columnHelper.accessor("Fit", {
         header: "Fit",
-        cell: (info) => <ScoreCell value={info.getValue()} />,
+        cell: (info) => <ScoreCell value={info.getValue()} max={10} />,
         size: 50,
       }),
       columnHelper.accessor("Ease", {
         header: "Ease",
-        cell: (info) => <ScoreCell value={info.getValue()} />,
+        cell: (info) => <ScoreCell value={info.getValue()} max={10} />,
         size: 55,
       }),
       columnHelper.accessor("score", {
-        header: "Match",
-        cell: (info) => <ScoreCell value={info.getValue() ?? 0} />,
+        header: "Match ★",
+        cell: (info) => <ScoreCell value={info.getValue() ?? 0} max={5} />,
         size: 65,
         sortingFn: (a, b) => {
           const sa = parseFloat(String(a.original.score ?? "0"));

--- a/ui/src/components/SummaryCards.tsx
+++ b/ui/src/components/SummaryCards.tsx
@@ -26,6 +26,9 @@ function Card({ label, value, sub, icon, accent }: CardProps) {
 }
 
 function parseScore(g: Grant): number {
+  // Prefer the personalized computed score; fall back to Weighted Score
+  const computed = g.score;
+  if (typeof computed === "number" && !isNaN(computed)) return computed;
   const v = g["Weighted Score"];
   if (typeof v === "number") return v;
   const n = parseFloat(String(v));
@@ -73,7 +76,7 @@ export default function SummaryCards({ grants }: Props) {
         accent="bg-blue-900/40"
       />
       <Card
-        label="Top Scored"
+        label="Top Match"
         value={topScore}
         sub={topName}
         icon="🏆"


### PR DESCRIPTION
SummaryCards was reading Weighted Score (raw data, scale ~0-20) while the Match column showed the computed personalized score (~0-5), making them appear contradictory. Now both use g.score (the personalized value). Also fixes ScoreCell color thresholds to use percentage-based coloring so green/yellow/red reflect relative quality regardless of column scale.

https://claude.ai/code/session_011CBTQ7ZaRosRkoQu4oDzzM