### PR TITLE
Add filter to show only saved grants (candidates + watchlist)

### DIFF
--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -35,6 +35,7 @@ const INITIAL_FILTERS: FilterState = {
   minScore: "",
   deadlineBefore: "",
   search: "",
+  savedOnly: false,
 };
 
 export default function Dashboard({ onLogout, onBackToProfile }: Props) {
@@ -117,7 +118,7 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
   const stages = [...new Set(grants.map((g) => g.Stage).filter(Boolean))].sort();
 
   const activeFilterCount = Object.entries(filters).filter(
-    ([, v]) => v !== ""
+    ([, v]) => v !== "" && v !== false
   ).length;
 
   async function handleExport() {
@@ -300,16 +301,12 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
 
               {(watchlist.size > 0 || candidates.size > 0) && (
                 <div className="flex flex-wrap gap-2 pt-1">
-                  {candidates.size > 0 && (
-                    <span className="badge bg-brand-900/50 text-brand-300">
-                      ★ {candidates.size} candidate{candidates.size !== 1 ? "s" : ""}
-                    </span>
-                  )}
-                  {watchlist.size > 0 && (
-                    <span className="badge bg-blue-900/50 text-blue-300">
-                      👁 {watchlist.size} on watchlist
-                    </span>
-                  )}
+                  <button
+                    onClick={() => setFilters((f) => ({ ...f, savedOnly: !f.savedOnly }))}
+                    className={`badge transition-colors cursor-pointer ${filters.savedOnly ? "bg-brand-600/60 text-brand-200 ring-1 ring-brand-400" : "bg-brand-900/50 text-brand-300 hover:bg-brand-800/50"}`}
+                  >
+                    ★ {candidates.size + watchlist.size} saved — {filters.savedOnly ? "showing saved" : "show saved"}
+                  </button>
                 </div>
               )}
             </div>

--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -82,6 +82,8 @@ export default function GrantTable({
 
   const filtered = useMemo(() => {
     return grants.filter((g) => {
+      const name = String(g.Name);
+      if (filters.savedOnly && !candidates.has(name) && !watchlist.has(name)) return false;
       if (filters.type && g.Type !== filters.type) return false;
       if (filters.stage && g.Stage !== filters.stage) return false;
       if (filters.minScore) {
@@ -103,7 +105,7 @@ export default function GrantTable({
       }
       return true;
     });
-  }, [grants, filters]);
+  }, [grants, filters, candidates, watchlist]);
 
   const columns = useMemo(
     () => [

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -33,4 +33,5 @@ export interface FilterState {
   minScore: string;
   deadlineBefore: string;
   search: string;
+  savedOnly: boolean;
 }


### PR DESCRIPTION
## Summary
This PR adds a new "saved only" filter to the Dashboard that allows users to quickly view only grants they've saved (either as candidates or on their watchlist). The filter is implemented as a clickable badge that toggles the filtered view.

## Key Changes
- Added `savedOnly: boolean` field to `FilterState` type to track filter state
- Updated filter initialization to include `savedOnly: false` as default
- Modified active filter count logic to properly handle boolean filter values (not just empty strings)
- Replaced separate candidate and watchlist badge displays with a single interactive "saved" badge that:
  - Shows combined count of saved grants (candidates + watchlist)
  - Toggles the filter when clicked
  - Displays visual feedback (different styling) when active
  - Shows contextual text ("show saved" vs "showing saved")
- Implemented filtering logic in `GrantTable` to exclude non-saved grants when `savedOnly` is enabled
- Updated `GrantTable` memo dependencies to include `candidates` and `watchlist` sets

## Implementation Details
- The saved badge uses Tailwind CSS for styling with active/inactive states
- Filter application happens at the table level, checking if a grant's name exists in either the candidates or watchlist sets
- The filter state is managed through the existing filters state object for consistency with other filters

https://claude.ai/code/session_01Xj4YTWMviC74SXYcN1GLCP