### PR TITLE
Fix notes saving with a dedicated /api/notes endpoint

### DIFF
--- a/functions/[[catchall]].js
+++ b/functions/[[catchall]].js
@@ -341,6 +341,24 @@ export async function onRequest(context) {
     });
   }
 
+  // Update notes for a single grant
+  if (url.pathname === "/api/notes" && request.method === "POST") {
+    if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+    if (!env.GRANT_MANAGER_DB) return new Response("Database not configured", { status: 503 });
+    const form = await request.formData();
+    const name = form.get("Name");
+    const notes = form.get("Notes/Actions") ?? "";
+    if (!name) return new Response("Missing Name", { status: 400 });
+    await env.GRANT_MANAGER_DB.prepare(
+      `UPDATE programs SET "Notes/Actions" = ? WHERE "Name" = ?`
+    )
+      .bind(notes, name)
+      .run();
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+    });
+  }
+
   // New schema entry
   if (url.pathname === "/new_schema") {
     if (!loggedIn) {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -52,7 +52,7 @@ export async function updateNotes(grantName: string, notes: string): Promise<voi
   const body = new FormData();
   body.append("Name", grantName);
   body.append("Notes/Actions", notes);
-  const res = await fetch(`${BASE}/new_schema`, {
+  const res = await fetch(`${BASE}/api/notes`, {
     method: "POST",
     body,
     credentials: "include",


### PR DESCRIPTION
The old /new_schema endpoint did INSERT OR REPLACE with all columns, wiping real data with empty strings, and returned a redirect instead of a JSON response. Replace it with a targeted UPDATE on just the Notes/Actions column and a proper 200 JSON response.

https://claude.ai/code/session_01Xj4YTWMviC74SXYcN1GLCP