### PR TITLE
Add Anthropic Claude support as alternative AI provider

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -153,3 +153,11 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Set ANTHROPIC_API_KEY Worker secret
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: echo "$ANTHROPIC_API_KEY" | npx wrangler secret put ANTHROPIC_API_KEY
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -35,8 +35,11 @@ function NoAiKeyBanner() {
     <div className="mx-4 my-3 bg-amber-900/30 border border-amber-700/50 rounded-lg p-3 text-sm">
       <p className="font-semibold text-amber-300 mb-1">⚠️ AI not configured</p>
       <p className="text-amber-200/80 text-xs leading-relaxed">
-        The AI binding is not set up on the worker. To enable chat, configure an AI binding in{" "}
-        <code className="bg-amber-900/50 px-1 rounded">wrangler.toml</code> and redeploy.
+        No AI provider is configured. Add an{" "}
+        <code className="bg-amber-900/50 px-1 rounded">ANTHROPIC_API_KEY</code> secret to your
+        Cloudflare Worker (or enable the{" "}
+        <code className="bg-amber-900/50 px-1 rounded">[ai]</code> binding in{" "}
+        <code className="bg-amber-900/50 px-1 rounded">wrangler.toml</code>) and redeploy.
       </p>
     </div>
   );

--- a/worker.js
+++ b/worker.js
@@ -305,19 +305,49 @@ if (url.pathname === "/api/profile") {
       if (!loggedIn) {
         return new Response("Unauthorized", { status: 401 });
       }
-      if (!env.AI) {
-        return new Response("AI binding not configured", { status: 503 });
-      }
       const { messages } = await request.json();
-      const result = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
-        messages: Array.isArray(messages)
-          ? messages
-          : [{ role: "user", content: String(messages || "") }],
-        stream: false,
-      });
-      return new Response(JSON.stringify({ response: result.response }), {
-        headers: { "content-type": "application/json" },
-      });
+      const chatMessages = Array.isArray(messages)
+        ? messages
+        : [{ role: "user", content: String(messages || "") }];
+
+      if (env.ANTHROPIC_API_KEY) {
+        const anthropicRes = await fetch("https://api.anthropic.com/v1/messages", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": env.ANTHROPIC_API_KEY,
+            "anthropic-version": "2023-06-01",
+          },
+          body: JSON.stringify({
+            model: "claude-haiku-4-5-20251001",
+            max_tokens: 1024,
+            system:
+              "You are a helpful grant research assistant. Help users analyze grant opportunities, compare funding sources, and answer questions about their grant data.",
+            messages: chatMessages,
+          }),
+        });
+        if (!anthropicRes.ok) {
+          const errText = await anthropicRes.text().catch(() => "");
+          return new Response(`AI request failed: ${errText}`, { status: 502 });
+        }
+        const data = await anthropicRes.json();
+        const text = data.content?.[0]?.text ?? "";
+        return new Response(JSON.stringify({ response: text }), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (env.AI) {
+        const result = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
+          messages: chatMessages,
+          stream: false,
+        });
+        return new Response(JSON.stringify({ response: result.response }), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      return new Response("AI binding not configured", { status: 503 });
     }
 
     if (url.pathname === "/logout") {


### PR DESCRIPTION
## Summary
This PR adds support for Anthropic's Claude API as an alternative AI provider alongside the existing Cloudflare AI binding. The implementation includes fallback logic that prioritizes Anthropic if configured, with graceful degradation to the Cloudflare AI binding.

## Key Changes
- **Worker API endpoint**: Modified `/api/profile` chat handler to support both Anthropic Claude and Cloudflare AI bindings
  - Attempts Anthropic API first if `ANTHROPIC_API_KEY` is configured
  - Falls back to Cloudflare AI binding if Anthropic is unavailable
  - Returns 503 error only if neither provider is configured
  - Uses Claude Haiku 4.5 model with appropriate system prompt for grant research assistance

- **CI/CD workflow**: Added GitHub Actions step to deploy `ANTHROPIC_API_KEY` as a Cloudflare Worker secret during deployment
  - Only runs if the secret is present in the repository
  - Properly passes required authentication tokens

- **UI messaging**: Updated the "AI not configured" warning banner to reflect both configuration options
  - Clarifies that users can add `ANTHROPIC_API_KEY` secret or enable the `[ai]` binding
  - Provides clearer guidance on how to enable chat functionality

## Implementation Details
- Anthropic integration uses the standard REST API endpoint with proper headers and version specification
- Error handling includes fallback text extraction for failed Anthropic requests
- Message format is normalized before being sent to either provider
- System prompt guides the AI to focus on grant research assistance

https://claude.ai/code/session_01K9etNdR6XJq93DtSFCRu6f