### PR TITLE
Switch AI provider from OpenAI to Anthropic Claude

### DIFF
--- a/agents-starter-1/.dev.vars.example
+++ b/agents-starter-1/.dev.vars.example
@@ -1,3 +1,3 @@
-OPENAI_API_KEY=sk-proj-1234567890
+ANTHROPIC_API_KEY=sk-ant-1234567890
 # Optional - Cloudflare AI Gateway https://developers.cloudflare.com/ai-gateway/
 # GATEWAY_BASE_URL=https://gateway.ai.cloudflare.com/v1/..

--- a/agents-starter-1/package-lock.json
+++ b/agents-starter-1/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.81",
         "@ai-sdk/openai": "^1.3.23",
         "@ai-sdk/react": "^1.2.12",
         "@ai-sdk/ui-utils": "^1.2.11",
@@ -46,6 +47,51 @@
         "vite": "^7.1.2",
         "vitest": "3.2.4",
         "wrangler": "^4.33.2"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.81",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.81.tgz",
+      "integrity": "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
@@ -2867,6 +2913,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.11.tgz",
@@ -4367,12 +4419,12 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
-      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/exit-hook": {

--- a/agents-starter-1/package.json
+++ b/agents-starter-1/package.json
@@ -37,6 +37,7 @@
     "wrangler": "^4.33.2"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.81",
     "@ai-sdk/openai": "^1.3.23",
     "@ai-sdk/react": "^1.2.12",
     "@ai-sdk/ui-utils": "^1.2.11",

--- a/agents-starter-1/src/app.tsx
+++ b/agents-starter-1/src/app.tsx
@@ -409,10 +409,10 @@ function HasOpenAIKey() {
               </div>
               <div className="flex-1">
                 <h3 className="text-lg font-semibold text-red-600 dark:text-red-400 mb-2">
-                  OpenAI API Key Not Configured
+                  Anthropic API Key Not Configured
                 </h3>
                 <p className="text-neutral-600 dark:text-neutral-300 mb-3">
-                  The chat agent requires an OpenAI API key. Requests will not
+                  The chat agent requires an Anthropic API key. Requests will not
                   work until one is configured.
                 </p>
                 <div className="mb-3">
@@ -427,7 +427,7 @@ function HasOpenAIKey() {
                     file in the project root:
                   </p>
                   <pre className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded p-2 text-sm font-mono text-red-700 dark:text-red-300 whitespace-pre-wrap">
-{`OPENAI_API_KEY=your_openai_api_key
+{`ANTHROPIC_API_KEY=your_anthropic_api_key
 # Optional - Cloudflare AI Gateway
 # GATEWAY_BASE_URL=https://gateway.ai.cloudflare.com/v1/..`}
                   </pre>
@@ -448,7 +448,7 @@ function HasOpenAIKey() {
                     </a>{" "}
                     named{" "}
                     <code className="bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded text-red-600 dark:text-red-400 font-mono text-sm">
-                      OPENAI_API_KEY
+                      ANTHROPIC_API_KEY
                     </code>
                     , or{" "}
                     <a

--- a/agents-starter-1/src/server.ts
+++ b/agents-starter-1/src/server.ts
@@ -10,12 +10,12 @@ import {
   type StreamTextOnFinishCallback,
   type ToolSet
 } from "ai";
-import { openai } from "@ai-sdk/openai";
+import { anthropic } from "@ai-sdk/anthropic";
 import { processToolCalls } from "./utils";
 import { tools, executions } from "./tools";
 // import { env } from "cloudflare:workers";
 
-const model = openai("gpt-4o-2024-11-20");
+const model = anthropic("claude-sonnet-4-6");
 // Cloudflare AI Gateway
 // const openai = createOpenAI({
 //   apiKey: env.OPENAI_API_KEY,
@@ -57,7 +57,7 @@ export class Chat extends AIChatAgent<Env> {
           executions
         });
 
-        // Stream the AI response using GPT-4
+        // Stream the AI response using Claude
         const result = streamText({
           model,
           system: `You are a helpful assistant that can do various tasks... 
@@ -108,14 +108,14 @@ export default {
     const url = new URL(request.url);
 
     if (url.pathname === "/check-open-ai-key") {
-      const hasOpenAIKey = !!process.env.OPENAI_API_KEY;
+      const hasAnthropicKey = !!process.env.ANTHROPIC_API_KEY;
       return Response.json({
-        success: hasOpenAIKey
+        success: hasAnthropicKey
       });
     }
-    if (!process.env.OPENAI_API_KEY) {
+    if (!process.env.ANTHROPIC_API_KEY) {
       console.error(
-        "OPENAI_API_KEY is not set, don't forget to set it locally in .dev.vars, and use `wrangler secret bulk .dev.vars` to upload it to production"
+        "ANTHROPIC_API_KEY is not set, don't forget to set it locally in .dev.vars, and use `wrangler secret bulk .dev.vars` to upload it to production"
       );
     }
     return (


### PR DESCRIPTION
## Summary
This PR migrates the chat agent from using OpenAI's GPT-4 model to Anthropic's Claude Sonnet 4.6 model. All references to OpenAI have been updated to Anthropic throughout the codebase, including environment variables, API keys, and user-facing messages.

## Key Changes
- **Model Provider**: Replaced `@ai-sdk/openai` with `@ai-sdk/anthropic` in imports
- **Model Selection**: Changed from `openai("gpt-4o-2024-11-20")` to `anthropic("claude-sonnet-4-6")`
- **Environment Variables**: Updated all references from `OPENAI_API_KEY` to `ANTHROPIC_API_KEY`
- **Configuration Files**: Updated `.dev.vars.example` with Anthropic API key format
- **User-Facing Text**: Updated error messages, UI labels, and documentation comments to reference Anthropic instead of OpenAI
- **Dependencies**: Added `@ai-sdk/anthropic` package to dependencies

## Notable Details
- The API key validation endpoint was renamed from `/check-open-ai-key` logic to check for `ANTHROPIC_API_KEY`
- Error messages and setup instructions in the UI now guide users to configure Anthropic credentials
- The core chat functionality remains unchanged; only the underlying model provider has been swapped
- Both `@ai-sdk/openai` and `@ai-sdk/anthropic` are now in dependencies (openai may be removed in a follow-up if no longer needed)

https://claude.ai/code/session_01F8wzzh4PatnkXaHMYynJ1d