### PR TITLE
Add /api/ai-status endpoint and proactive AI banner check

### DIFF
--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -62,6 +62,13 @@ export default function ChatPanel({ open, onClose }: Props) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
+    fetch("/api/ai-status")
+      .then((r) => r.json() as Promise<{ configured: boolean; provider: string | null }>)
+      .then((data) => { if (!data.configured) setAiUnavailable(true); })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     if (open) {
       setTimeout(() => textareaRef.current?.focus(), 100);
     }
@@ -172,7 +179,7 @@ export default function ChatPanel({ open, onClose }: Props) {
           <div className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full bg-brand-500 animate-pulse" />
             <h2 className="font-semibold text-white text-sm">AI Assistant</h2>
-            <span className="badge bg-gray-800 text-gray-400 text-xs">Llama 3</span>
+            <span className="badge bg-gray-800 text-gray-400 text-xs">Claude</span>
           </div>
           <div className="flex items-center gap-1">
             <button onClick={handleClear} className="btn-ghost px-2 py-1 text-xs">

--- a/worker.js
+++ b/worker.js
@@ -234,6 +234,14 @@ if (url.pathname === "/api/profile") {
       }
     }
 
+    if (url.pathname === "/api/ai-status") {
+      const hasAnthropic = !!env.ANTHROPIC_API_KEY;
+      const hasWorkersAI = !!env.AI;
+      const configured = hasAnthropic || hasWorkersAI;
+      const provider = hasAnthropic ? "anthropic" : hasWorkersAI ? "workers-ai" : null;
+      return jsonResponse(JSON.stringify({ configured, provider }));
+    }
+
     if (url.pathname === "/api/grants") {
       if (!loggedIn) {
         return new Response("Unauthorized", { status: 401 });
@@ -308,7 +316,7 @@ if (url.pathname === "/api/profile") {
             "anthropic-version": "2023-06-01",
           },
           body: JSON.stringify({
-            model: "claude-haiku-4-5-20251001",
+            model: "claude-haiku-4-5",
             max_tokens: 1024,
             system:
               "You are a helpful grant research assistant. Help users analyze grant opportunities, compare funding sources, and answer questions about their grant data.",


### PR DESCRIPTION
Worker now exposes GET /api/ai-status so the UI can check at mount time whether ANTHROPIC_API_KEY or the Workers AI binding is configured, rather than only discovering it after the first failed chat request.

Also updates the chat panel badge from "Llama 3" to "Claude" and normalizes the Anthropic model ID to claude-haiku-4-5.

https://claude.ai/code/session_01F8wzzh4PatnkXaHMYynJ1d