### PR TITLE
Remove API key requirement from agents-starter env config

### DIFF
--- a/agents-starter-1/.dev.vars.example
+++ b/agents-starter-1/.dev.vars.example
@@ -1,3 +1,2 @@
-ANTHROPIC_API_KEY=sk-ant-1234567890
 # Optional - Cloudflare AI Gateway https://developers.cloudflare.com/ai-gateway/
 # GATEWAY_BASE_URL=https://gateway.ai.cloudflare.com/v1/..


### PR DESCRIPTION
No external API key needed — inference runs via the env.AI Workers AI binding.

https://claude.ai/code/session_0125bHmnjYeo1oidrwkSfYX9