### PR TITLE
Move USER_HASHES to Cloudflare Secrets in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,8 +407,9 @@ queue = "PDF_INGEST"
 queue = "SCORE_QUEUE"
 binding = "SCORE_QUEUE"
 
-[vars]
-USER_HASHES = '{"admin":"...","user":"..."}'
+# USER_HASHES must be set as a Cloudflare Secret, not a [vars] entry:
+# wrangler secret put USER_HASHES
+# When prompted, paste a JSON string: '{"admin":"<sha256hex>","user":"<sha256hex>"}'
 ```
 
 #### Database Schema
@@ -789,7 +790,7 @@ UI Components
 
 3. **Security Concerns:**
    - Hardcoded secret key in visualize_grants_web.py
-   - USER_HASHES visible in wrangler.toml (should use secrets)
+   - USER_HASHES must be stored as a Cloudflare Secret (`wrangler secret put USER_HASHES`), not in wrangler.toml
 
 4. **Architecture Confusion:**
    - Dual worker setup (worker.js vs worker/src/worker.ts)
@@ -909,7 +910,7 @@ For issues or questions:
 
 **Worker Login:**
 - Username: `demo`, Password: `demo`
-- Username: `admin`, Password: (see USER_HASHES in wrangler.toml)
+- Username: `admin`, Password: (set via `wrangler secret put USER_HASHES`)
 
 **Python GUI:**
 - Username: `admin`, Password: `adminpass`

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ pip install -r requirements.txt
 
 ## Cloudflare Worker Demo
 
-A minimal Cloudflare Worker publishes a demo endpoint with a basic login page configured via the `USER_HASHES` environment variable. Failed login attempts are stored in the `LOGIN_ATTEMPTS` KV namespace to enforce a five-try, five-minute lockout. After logging in, the `/dashboard` view renders the program data schema table with links to `/schema` (JSON) and `/data` (CSV). Authenticated requests to `/api/grants` return grant rows scored with weights from the user's profile stored in the `USER_PROFILES` KV namespace. If that binding is missing, the Worker logs a warning and falls back to an empty profile, and `/api/grants` responds with an explanatory error.
+A minimal Cloudflare Worker publishes a demo endpoint with a basic login page configured via the `USER_HASHES` Cloudflare Secret (set with `wrangler secret put USER_HASHES`). Failed login attempts are stored in the `LOGIN_ATTEMPTS` KV namespace to enforce a five-try, five-minute lockout. After logging in, the `/dashboard` view renders the program data schema table with links to `/schema` (JSON) and `/data` (CSV). Authenticated requests to `/api/grants` return grant rows scored with weights from the user's profile stored in the `USER_PROFILES` KV namespace. If that binding is missing, the Worker logs a warning and falls back to an empty profile, and `/api/grants` responds with an explanatory error.
 
 The Worker relies on a D1 database. Run the migration before deploying:
 

--- a/docs/pipeline_vs_direct_write.md
+++ b/docs/pipeline_vs_direct_write.md
@@ -15,7 +15,7 @@ This guide summarizes the tradeoffs between running the full processing pipeline
 - Choose **direct write** for quick prototypes or small datasets where infrastructure costs must be minimal.
 
 ## Required configuration variables
-- `USER_HASHES` – credential hash mapping for the demo login.
+- `USER_HASHES` – credential hash mapping for the demo login. **Must be stored as a Cloudflare Secret** (`wrangler secret put USER_HASHES`), not in `wrangler.toml`.
 - `USER_PROFILES` – KV namespace storing weight profiles.
 - `PDF_BUCKET` – R2 bucket holding uploaded PDFs and generated summaries.
 - `PDF_INGEST` – queue delivering PDF keys to extraction workers.


### PR DESCRIPTION
Replace all references instructing users to put USER_HASHES in wrangler.toml [vars] with instructions to use `wrangler secret put`. Credentials must not live in version-controlled config files.

https://claude.ai/code/session_01B3wGHGr7vYCN11EryqZxQb