### PR TITLE
Update wrangler secret commands to use versions subcommand

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Set Workers AI secrets
         run: |
-          echo "$CLOUDFLARE_ACCOUNT_ID" | npx wrangler secret put CF_ACCOUNT_ID
-          echo "$CLOUDFLARE_API_TOKEN"   | npx wrangler secret put CF_AI_TOKEN
+          echo "$CLOUDFLARE_ACCOUNT_ID" | npx wrangler versions secret put CF_ACCOUNT_ID
+          echo "$CLOUDFLARE_API_TOKEN"   | npx wrangler versions secret put CF_AI_TOKEN
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
Updated the Workers CI workflow to use the `wrangler versions secret put` command instead of the deprecated `wrangler secret put` command when setting up Cloudflare Workers AI secrets.

## Key Changes
- Changed `npx wrangler secret put CF_ACCOUNT_ID` to `npx wrangler versions secret put CF_ACCOUNT_ID`
- Changed `npx wrangler secret put CF_AI_TOKEN` to `npx wrangler versions secret put CF_AI_TOKEN`

## Details
This change aligns with the updated wrangler CLI API where secret management for Workers now uses the `versions` subcommand. This ensures the CI/CD pipeline uses the correct command syntax for the current version of wrangler.

https://claude.ai/code/session_01PZYRKSaCkM3A9nD14J672q