### PR TITLE
Paginate /api/grants for scalability headroom

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -386,14 +386,16 @@ describe("/api/profile", () => {
 describe("GET /api/grants — scoring", () => {
   beforeEach(seedPrograms);
 
-  it("returns an array of grants with a score field", async () => {
+  it("returns paginated envelope with data array and total", async () => {
     const { token } = await createAndLoginUser("karen", "password1x");
     const res = await authedGet("/api/grants", token);
     expect(res.status).toBe(200);
-    const grants = await res.json();
-    expect(Array.isArray(grants)).toBe(true);
-    expect(grants.length).toBe(3);
-    for (const g of grants) {
+    const body = await res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.total).toBe(3);
+    expect(body.page).toBe(1);
+    expect(typeof body.pageSize).toBe("number");
+    for (const g of body.data) {
       expect(typeof g.score).toBe("number");
       expect(g.score).toBeGreaterThanOrEqual(0);
     }
@@ -402,10 +404,27 @@ describe("GET /api/grants — scoring", () => {
   it("returns grants sorted by score descending", async () => {
     const { token } = await createAndLoginUser("lena", "password1x");
     const res = await authedGet("/api/grants", token);
-    const grants = await res.json();
+    const { data: grants } = await res.json();
     for (let i = 1; i < grants.length; i++) {
       expect(grants[i - 1].score).toBeGreaterThanOrEqual(grants[i].score);
     }
+  });
+
+  it("paginates correctly with page and pageSize params", async () => {
+    const { token } = await createAndLoginUser("lena2", "password1x");
+    const res1 = await authedGet("/api/grants?page=1&pageSize=2", token);
+    const body1 = await res1.json();
+    expect(body1.data.length).toBe(2);
+    expect(body1.total).toBe(3);
+    expect(body1.page).toBe(1);
+    const res2 = await authedGet("/api/grants?page=2&pageSize=2", token);
+    const body2 = await res2.json();
+    expect(body2.data.length).toBe(1);
+    expect(body2.page).toBe(2);
+    // No overlap between pages
+    const names1 = body1.data.map((g) => g.Name);
+    const names2 = body2.data.map((g) => g.Name);
+    expect(names1.every((n) => !names2.includes(n))).toBe(true);
   });
 
   it("applies custom weights from user profile", async () => {
@@ -414,14 +433,14 @@ describe("GET /api/grants — scoring", () => {
     await authedPostJson("/api/profile", token, csrf,
       { weights: { Relevance: 0, Fit: 0, Ease: 1, StackAlignment: 0, CadenceRecency: 0 } });
     const res = await authedGet("/api/grants", token);
-    const grants = await res.json();
+    const { data: grants } = await res.json();
     expect(grants[0].Name).toBe("Grant Beta");
   });
 
   it("applies default weights when no profile exists", async () => {
     const { token } = await createAndLoginUser("nina", "password1x");
     const res = await authedGet("/api/grants", token);
-    const grants = await res.json();
+    const { data: grants } = await res.json();
     expect(grants[0].Name).toBe("Grant Alpha");
   });
 
@@ -430,7 +449,7 @@ describe("GET /api/grants — scoring", () => {
     await authedPostJson("/api/profile", token, csrf,
       { weights: { Relevance: 0, Fit: 0, Ease: 0, StackAlignment: 1, CadenceRecency: 0 } });
     const res = await authedGet("/api/grants", token);
-    const grants = await res.json();
+    const { data: grants } = await res.json();
     expect(grants[0].Name).toBe("Grant Beta");
   });
 
@@ -439,7 +458,7 @@ describe("GET /api/grants — scoring", () => {
     await authedPostJson("/api/profile", token, csrf,
       { weights: { Relevance: 0, Fit: 0, Ease: 0, StackAlignment: 0, CadenceRecency: 1 } });
     const res = await authedGet("/api/grants", token);
-    const grants = await res.json();
+    const { data: grants } = await res.json();
     expect(grants[0].Name).toBe("Grant Alpha");
   });
 
@@ -448,7 +467,7 @@ describe("GET /api/grants — scoring", () => {
     await authedPostJson("/api/profile", token, csrf,
       { weights: { Relevance: 0, Fit: 0, Ease: 0, StackAlignment: 0, CadenceRecency: 1 } });
     const res = await authedGet("/api/grants", token);
-    const grants = await res.json();
+    const { data: grants } = await res.json();
     const beta = grants.find((g) => g.Name === "Grant Beta");
     expect(beta.score).toBe(0);
   });
@@ -462,7 +481,7 @@ describe("GET /api/grants — scoring", () => {
     await authedPostJson("/api/profile", token, csrf,
       { weights: { Relevance: 0, Fit: 0, Ease: 0, StackAlignment: 0, CadenceRecency: 1 } });
     const res = await authedGet("/api/grants", token);
-    const grants = await res.json();
+    const { data: grants } = await res.json();
     const past = grants.find((g) => g.Name === "Grant Past");
     expect(past.score).toBe(0);
   });

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -61,9 +61,16 @@ export async function logout(): Promise<void> {
   await fetch(`${BASE}/logout`, { credentials: "include" });
 }
 
-export async function fetchGrants(): Promise<Grant[]> {
-  const res = await fetch(`${BASE}/api/grants`, { credentials: "include" });
-  return handleResponse<Grant[]>(res);
+export interface PagedGrants {
+  data: Grant[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export async function fetchGrants(page = 1, pageSize = 500): Promise<PagedGrants> {
+  const res = await fetch(`${BASE}/api/grants?page=${page}&pageSize=${pageSize}`, { credentials: "include" });
+  return handleResponse<PagedGrants>(res);
 }
 
 export async function updateNotes(grantName: string, notes: string): Promise<void> {

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import type { Grant, FilterState } from "../types";
 import { fetchGrants, logout, exportCsv, fetchProfile, saveProfile } from "../api";
+import type { PagedGrants } from "../api";
 import type { UserProfile } from "../api";
 import SummaryCards from "./SummaryCards";
 import GrantTable from "./GrantTable";
@@ -40,6 +41,7 @@ const INITIAL_FILTERS: FilterState = {
 
 export default function Dashboard({ onLogout, onBackToProfile }: Props) {
   const [grants, setGrants] = useState<Grant[]>([]);
+  const [grantsTotal, setGrantsTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -55,7 +57,7 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
 
   useEffect(() => {
     fetchGrants()
-      .then(setGrants)
+      .then(({ data, total }: PagedGrants) => { setGrants(data); setGrantsTotal(total); })
       .catch((e) => {
         if (e.message === "Unauthenticated") {
           onLogout();
@@ -75,8 +77,9 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
       setProfileOpen(false);
       // Reload grants with new profile scoring
       setLoading(true);
-      const updated = await fetchGrants();
+      const { data: updated, total } = await fetchGrants();
       setGrants(updated);
+      setGrantsTotal(total);
     } catch {
       // ignore
     } finally {
@@ -138,7 +141,7 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
           <div>
             <h1 className="text-base font-semibold text-white leading-tight">Grant Manager</h1>
             {!loading && (
-              <p className="text-gray-500 text-xs">{grants.length} programs loaded</p>
+              <p className="text-gray-500 text-xs">{grantsTotal} programs loaded</p>
             )}
           </div>
         </div>

--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   useReactTable,
   getCoreRowModel,
@@ -8,6 +8,8 @@ import {
   createColumnHelper,
   type SortingState,
 } from "@tanstack/react-table";
+
+const PAGE_SIZE = 25;
 import type { Grant, FilterState } from "../types";
 
 interface Props {
@@ -79,6 +81,9 @@ export default function GrantTable({
   const [sorting, setSorting] = useState<SortingState>([
     { id: "score", desc: true },
   ]);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => { setPage(1); }, [filters, grants]);
 
   const filtered = useMemo(() => {
     return grants.filter((g) => {
@@ -234,6 +239,11 @@ export default function GrantTable({
     getFilteredRowModel: getFilteredRowModel(),
   });
 
+  const allSortedRows = table.getRowModel().rows;
+  const pageCount = Math.max(1, Math.ceil(allSortedRows.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount);
+  const pageRows = allSortedRows.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
   if (filtered.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-gray-500">
@@ -268,7 +278,7 @@ export default function GrantTable({
           ))}
         </thead>
         <tbody>
-          {table.getRowModel().rows.map((row) => {
+          {pageRows.map((row) => {
             const name = String(row.original.Name);
             const isCandidate = candidates.has(name);
             const isWatchlisted = watchlist.has(name);
@@ -288,9 +298,34 @@ export default function GrantTable({
           })}
         </tbody>
       </table>
-      <p className="text-center text-gray-600 text-xs py-3">
-        Showing {filtered.length} of {grants.length} grants
-      </p>
+      <div className="flex items-center justify-between px-3 py-2.5 border-t border-gray-800 text-xs text-gray-500">
+        <span>
+          {filtered.length === grants.length
+            ? `${grants.length} grants`
+            : `${filtered.length} of ${grants.length} grants`}
+        </span>
+        {pageCount > 1 && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={safePage === 1}
+              className="px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              ‹ Prev
+            </button>
+            <span className="tabular-nums">
+              {safePage} / {pageCount}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
+              disabled={safePage === pageCount}
+              className="px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              Next ›
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/worker.js
+++ b/worker.js
@@ -304,22 +304,28 @@ export default {
         ? profile.weights
         : null;
 
+      const page = Math.max(1, parseInt(url.searchParams.get("page") || "1", 10));
+      const pageSize = Math.min(500, Math.max(1, parseInt(url.searchParams.get("pageSize") || "100", 10)));
+
       const grantsStart = Date.now();
       const columns = await getColumns(env.GRANT_MANAGER_DB);
-      let results = [];
+      let scored = [];
       if (columns.length > 0) {
         const { results: rows } = await env.GRANT_MANAGER_DB.prepare(
           `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
         ).all();
-        results = rows
+        scored = rows
           .map((r) => ({
             ...r,
             score: Math.round(computeScore(r, userWeights) * 100) / 100,
           }))
           .sort((a, b) => b.score - a.score);
       }
-      log("info", "grants_fetched", { ...reqCtx, rowCount: results.length, durationMs: Date.now() - grantsStart });
-      return jsonResponse(JSON.stringify(results));
+      const total = scored.length;
+      const start = (page - 1) * pageSize;
+      const data = scored.slice(start, start + pageSize);
+      log("info", "grants_fetched", { ...reqCtx, total, page, pageSize, durationMs: Date.now() - grantsStart });
+      return jsonResponse(JSON.stringify({ data, total, page, pageSize }));
     }
 
     if (url.pathname === "/api/me") {


### PR DESCRIPTION
Worker: /api/grants now accepts ?page=N&pageSize=M (default pageSize=100, max 500). Returns {data, total, page, pageSize} envelope instead of a bare array; scores and sorts all rows in memory then slices the requested page.

API: fetchGrants(page, pageSize) returns PagedGrants envelope; frontend defaults to pageSize=500 to load all data in one shot while the API is ready for true server-side pagination.

UI: GrantTable shows 25 rows per page with Prev/Next controls in the footer. Page resets to 1 whenever filters or the grant list changes. Footer shows filtered vs total count.

Tests: updated scoring suite to destructure {data} from the envelope; added a dedicated pagination test verifying page/pageSize slicing and zero overlap between pages.

https://claude.ai/code/session_01P59sK6Mdp5HW9HcaZBHoit