### PR TITLE
Add ARIA labels and text-based urgency indicators

### DIFF
--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -165,11 +165,14 @@ export default function ChatPanel({ open, onClose }: Props) {
     <>
       {/* Backdrop (mobile) */}
       {open && (
-        <div className="fixed inset-0 bg-black/50 z-30 lg:hidden" onClick={onClose} />
+        <div aria-hidden="true" className="fixed inset-0 bg-black/50 z-30 lg:hidden" onClick={onClose} />
       )}
 
       {/* Panel */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="AI Chat Assistant"
         className={`fixed right-0 top-0 h-full w-full max-w-sm bg-gray-900 border-l border-gray-800 z-40 flex flex-col transition-transform duration-300 ease-out ${open ? "translate-x-0" : "translate-x-full"}`}
       >
         {/* Header */}
@@ -180,11 +183,11 @@ export default function ChatPanel({ open, onClose }: Props) {
             <span className="badge bg-gray-800 text-gray-400 text-xs">Claude</span>
           </div>
           <div className="flex items-center gap-1">
-            <button onClick={handleClear} className="btn-ghost px-2 py-1 text-xs">
+            <button onClick={handleClear} className="btn-ghost px-2 py-1 text-xs" aria-label="Clear conversation">
               Clear
             </button>
-            <button onClick={onClose} className="btn-ghost p-1.5" aria-label="Close chat">
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <button onClick={onClose} className="btn-ghost p-1.5" aria-label="Close AI chat">
+              <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -194,21 +197,27 @@ export default function ChatPanel({ open, onClose }: Props) {
         {aiUnavailable && <NoAiKeyBanner />}
 
         {/* Messages */}
-        <div className="flex-1 overflow-y-auto px-4 py-4">
+        <div
+          role="log"
+          aria-live="polite"
+          aria-label="Chat messages"
+          className="flex-1 overflow-y-auto px-4 py-4"
+        >
           {messages.map((msg, i) => (
             <MessageBubble key={i} msg={msg} />
           ))}
           {loading && messages[messages.length - 1]?.content === "" && (
-            <div className="flex justify-start mb-3">
-              <div className="w-7 h-7 rounded-full bg-brand-600 flex items-center justify-center text-xs font-bold mr-2 shrink-0">
+            <div className="flex justify-start mb-3" aria-label="AI is typing" role="status">
+              <div className="w-7 h-7 rounded-full bg-brand-600 flex items-center justify-center text-xs font-bold mr-2 shrink-0" aria-hidden="true">
                 AI
               </div>
               <div className="bg-gray-800 rounded-2xl rounded-bl-sm px-4 py-3">
-                <div className="flex gap-1">
+                <div className="flex gap-1" aria-hidden="true">
                   <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
                   <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
                   <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
                 </div>
+                <span className="sr-only">AI is typing…</span>
               </div>
             </div>
           )}
@@ -226,6 +235,7 @@ export default function ChatPanel({ open, onClose }: Props) {
           <div className="flex gap-2 items-end">
             <textarea
               ref={textareaRef}
+              aria-label="Message input"
               className="input resize-none flex-1 min-h-[2.5rem] max-h-32 leading-relaxed"
               rows={1}
               placeholder="Ask about grants… (Enter to send)"
@@ -241,17 +251,19 @@ export default function ChatPanel({ open, onClose }: Props) {
             {loading ? (
               <button
                 onClick={handleStop}
+                aria-label="Stop generating"
                 className="btn-outline px-3 py-2 shrink-0 text-red-400 border-red-800 hover:bg-red-900/20"
               >
-                ■
+                <span aria-hidden="true">■</span>
               </button>
             ) : (
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}
+                aria-label="Send message"
                 className="btn-primary px-3 py-2 shrink-0"
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                 </svg>
               </button>

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -164,9 +164,9 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
           <button
             onClick={handleExport}
             className="btn-outline hidden sm:flex gap-1.5"
-            title="Export CSV"
+            aria-label="Export grants to CSV"
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
             Export CSV
@@ -185,9 +185,9 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
           <button
             onClick={handleLogout}
             className="btn-ghost px-2.5"
-            title="Sign out"
+            aria-label="Sign out"
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
             </svg>
           </button>
@@ -246,7 +246,9 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
 
               <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
                 <div className="col-span-2 sm:col-span-3 lg:col-span-1">
+                  <label htmlFor="filter-search" className="sr-only">Search by name or sponsor</label>
                   <input
+                    id="filter-search"
                     className="input"
                     placeholder="Search name, sponsor…"
                     value={filters.search}
@@ -254,8 +256,11 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
                   />
                 </div>
 
+                <label htmlFor="filter-type" className="sr-only">Filter by type</label>
                 <select
+                  id="filter-type"
                   className="input"
+                  aria-label="Filter by type"
                   value={filters.type}
                   onChange={(e) => setFilters((f) => ({ ...f, type: e.target.value }))}
                 >
@@ -265,8 +270,11 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
                   ))}
                 </select>
 
+                <label htmlFor="filter-stage" className="sr-only">Filter by stage</label>
                 <select
+                  id="filter-stage"
                   className="input"
+                  aria-label="Filter by stage"
                   value={filters.stage}
                   onChange={(e) => setFilters((f) => ({ ...f, stage: e.target.value }))}
                 >
@@ -277,23 +285,28 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
                 </select>
 
                 <div>
+                  <label htmlFor="filter-score" className="sr-only">Minimum match score</label>
                   <input
+                    id="filter-score"
                     className="input"
                     type="number"
                     min={0}
                     max={10}
                     step={0.5}
                     placeholder="Min score (0–10)"
+                    aria-label="Minimum match score"
                     value={filters.minScore}
                     onChange={(e) => setFilters((f) => ({ ...f, minScore: e.target.value }))}
                   />
                 </div>
 
                 <div>
+                  <label htmlFor="filter-deadline" className="sr-only">Deadline before date</label>
                   <input
+                    id="filter-deadline"
                     className="input"
                     type="date"
-                    title="Deadline before"
+                    aria-label="Show grants with deadline before this date"
                     value={filters.deadlineBefore}
                     onChange={(e) =>
                       setFilters((f) => ({ ...f, deadlineBefore: e.target.value }))
@@ -346,7 +359,7 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
 
       {/* Profile modal */}
       {profileOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+        <div role="dialog" aria-modal="true" aria-label="Profile settings" className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
           <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto">
             <ProfileSetup
               initial={profile}

--- a/ui/src/components/GrantDrawer.tsx
+++ b/ui/src/components/GrantDrawer.tsx
@@ -32,15 +32,18 @@ const COLUMNS: (keyof Grant)[] = [
 
 function ScoreBadge({ value }: { value: string | number }) {
   const n = parseFloat(String(value));
-  if (isNaN(n)) return <span className="text-gray-400">—</span>;
+  if (isNaN(n)) return <span className="text-gray-400" aria-label="No score">—</span>;
   const color =
     n >= 7
       ? "bg-green-900/50 text-green-300"
       : n >= 4
         ? "bg-yellow-900/50 text-yellow-300"
         : "bg-red-900/50 text-red-300";
+  const level = n >= 7 ? "high" : n >= 4 ? "medium" : "low";
   return (
-    <span className={`badge ${color} font-semibold text-sm px-2 py-0.5`}>{n.toFixed(1)}</span>
+    <span className={`badge ${color} font-semibold text-sm px-2 py-0.5`} aria-label={`${n.toFixed(1)}, ${level}`}>
+      <span aria-hidden="true">{n.toFixed(1)}</span>
+    </span>
   );
 }
 
@@ -50,12 +53,15 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
   const [saveError, setSaveError] = useState("");
   const [saved, setSaved] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (grant) {
       setNotes(String(grant["Notes/Actions"] || ""));
       setSaved(false);
       setSaveError("");
+      // Move focus into the drawer when it opens
+      setTimeout(() => closeBtnRef.current?.focus(), 50);
     }
   }, [grant]);
 
@@ -90,6 +96,7 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
     <>
       {/* Backdrop */}
       <div
+        aria-hidden="true"
         className={`fixed inset-0 bg-black/60 z-40 transition-opacity duration-200 ${grant ? "opacity-100" : "opacity-0 pointer-events-none"}`}
         onClick={onClose}
       />
@@ -97,6 +104,10 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
       {/* Drawer */}
       <div
         ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drawer-title"
+        aria-label={grant ? `Grant details: ${grant.Name}` : "Grant details"}
         className={`fixed right-0 top-0 h-full w-full max-w-xl bg-gray-900 border-l border-gray-800 z-50 flex flex-col transition-transform duration-300 ease-out ${grant ? "translate-x-0" : "translate-x-full"}`}
       >
         {grant && (
@@ -108,7 +119,7 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
                   <span className="badge bg-gray-800 text-gray-300 text-xs">{grant.Type || "—"}</span>
                   <ScoreBadge value={grant["Weighted Score"]} />
                 </div>
-                <h2 className="text-lg font-semibold text-white leading-snug">{grant.Name}</h2>
+                <h2 id="drawer-title" className="text-lg font-semibold text-white leading-snug">{grant.Name}</h2>
                 <p className="text-gray-400 text-sm">{grant.Sponsor}</p>
               </div>
               <div className="flex items-center gap-1 shrink-0">
@@ -119,24 +130,26 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
                   return (
                     <>
                       <button
-                        title={isCandidate ? "Remove from candidates" : "Mark as candidate"}
+                        aria-label={isCandidate ? "Remove from candidates" : "Mark as candidate"}
+                        aria-pressed={isCandidate}
                         onClick={() => onToggleCandidate(name)}
                         className={`p-1.5 rounded transition-colors text-lg leading-none ${isCandidate ? "text-brand-400" : "text-gray-600 hover:text-gray-400"}`}
                       >
-                        ★
+                        <span aria-hidden="true">★</span>
                       </button>
                       <button
-                        title={isWatchlisted ? "Remove from watchlist" : "Add to watchlist"}
+                        aria-label={isWatchlisted ? "Remove from watchlist" : "Add to watchlist"}
+                        aria-pressed={isWatchlisted}
                         onClick={() => onToggleWatchlist(name)}
                         className={`p-1.5 rounded transition-colors text-base leading-none ${isWatchlisted ? "text-blue-400" : "text-gray-600 hover:text-gray-400"}`}
                       >
-                        👁
+                        <span aria-hidden="true">👁</span>
                       </button>
                     </>
                   );
                 })()}
-                <button onClick={onClose} className="btn-ghost p-1.5 ml-1" aria-label="Close">
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <button ref={closeBtnRef} onClick={onClose} className="btn-ghost p-1.5 ml-1" aria-label="Close grant details">
+                  <svg className="w-5 h-5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>
@@ -183,10 +196,11 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
 
               {/* Notes editor */}
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="grant-notes" className="block text-sm font-medium text-gray-300 mb-2">
                   Notes / Actions
                 </label>
                 <textarea
+                  id="grant-notes"
                   className="input resize-none h-28 leading-relaxed"
                   value={notes}
                   onChange={(e) => setNotes(e.target.value)}

--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -26,7 +26,7 @@ const columnHelper = createColumnHelper<Grant>();
 
 function ScoreCell({ value, max = 5 }: { value: string | number; max?: number }) {
   const n = parseFloat(String(value));
-  if (isNaN(n)) return <span className="text-gray-500">—</span>;
+  if (isNaN(n)) return <span className="text-gray-500" aria-label="No score">—</span>;
   const pct = n / max;
   const color =
     pct >= 0.65
@@ -34,7 +34,13 @@ function ScoreCell({ value, max = 5 }: { value: string | number; max?: number })
       : pct >= 0.35
         ? "text-yellow-400"
         : "text-red-400";
-  return <span className={`font-semibold ${color}`}>{n.toFixed(1)}</span>;
+  const level = pct >= 0.65 ? "high" : pct >= 0.35 ? "medium" : "low";
+  return (
+    <>
+      <span className={`font-semibold ${color}`} aria-hidden="true">{n.toFixed(1)}</span>
+      <span className="sr-only">{n.toFixed(1)} out of {max}, {level}</span>
+    </>
+  );
 }
 
 function BoolCell({ value }: { value: string | number }) {
@@ -48,23 +54,36 @@ function BoolCell({ value }: { value: string | number }) {
 
 function DeadlineCell({ value }: { value: string | number }) {
   const raw = String(value || "");
-  if (!raw) return <span className="text-gray-500">—</span>;
+  if (!raw) return <span className="text-gray-500" aria-label="No deadline">—</span>;
   const d = new Date(raw);
   if (isNaN(d.getTime())) return <span className="text-gray-300 text-xs">{raw}</span>;
   const now = Date.now();
-  const diff = d.getTime() - now;
-  const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
-  const color =
-    days < 0
-      ? "text-gray-500 line-through"
-      : days < 30
-        ? "text-red-400"
-        : days < 90
-          ? "text-yellow-400"
-          : "text-gray-300";
+  const days = Math.ceil((d.getTime() - now) / (1000 * 60 * 60 * 24));
+  const isPast = days < 0;
+  const isUrgent = !isPast && days < 30;
+  const isSoon = !isPast && days < 90;
+  const color = isPast
+    ? "text-gray-500 line-through"
+    : isUrgent
+      ? "text-red-400"
+      : isSoon
+        ? "text-yellow-400"
+        : "text-gray-300";
+  const dateStr = d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  const urgencyText = isPast ? "Past" : isUrgent ? "Urgent" : isSoon ? "Soon" : "";
   return (
-    <span className={`text-xs ${color}`}>
-      {d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+    <span className="inline-flex items-center gap-1 flex-wrap" aria-label={isPast ? `Deadline passed: ${dateStr}` : urgencyText ? `Deadline: ${dateStr}, ${urgencyText}` : `Deadline: ${dateStr}`}>
+      <span className={`text-xs ${color}`} aria-hidden="true">{dateStr}</span>
+      {isUrgent && (
+        <span className="inline-block px-1 py-px text-[10px] font-bold uppercase tracking-wide bg-red-900/50 text-red-300 rounded leading-none">
+          Urgent
+        </span>
+      )}
+      {!isUrgent && isSoon && (
+        <span className="inline-block px-1 py-px text-[10px] font-bold uppercase tracking-wide bg-yellow-900/40 text-yellow-400 rounded leading-none">
+          Soon
+        </span>
+      )}
     </span>
   );
 }
@@ -206,18 +225,20 @@ export default function GrantTable({
           return (
             <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
               <button
-                title={isCandidate ? "Remove from candidates" : "Mark as candidate"}
+                aria-label={isCandidate ? `Remove ${name} from candidates` : `Mark ${name} as candidate`}
+                aria-pressed={isCandidate}
                 onClick={() => onToggleCandidate(name)}
                 className={`p-1 rounded transition-colors text-base leading-none ${isCandidate ? "text-brand-400" : "text-gray-600 hover:text-gray-400"}`}
               >
-                ★
+                <span aria-hidden="true">★</span>
               </button>
               <button
-                title={isWatchlisted ? "Remove from watchlist" : "Add to watchlist"}
+                aria-label={isWatchlisted ? `Remove ${name} from watchlist` : `Add ${name} to watchlist`}
+                aria-pressed={isWatchlisted}
                 onClick={() => onToggleWatchlist(name)}
                 className={`p-1 rounded transition-colors text-sm leading-none ${isWatchlisted ? "text-blue-400" : "text-gray-600 hover:text-gray-400"}`}
               >
-                👁
+                <span aria-hidden="true">👁</span>
               </button>
             </div>
           );
@@ -256,24 +277,29 @@ export default function GrantTable({
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-sm border-separate border-spacing-0">
+      <table className="w-full text-sm border-separate border-spacing-0" aria-label="Grant opportunities">
         <thead>
           {table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>
-              {hg.headers.map((header) => (
-                <th
-                  key={header.id}
-                  style={{ width: header.getSize() }}
-                  className={`sticky top-0 bg-gray-900 px-3 py-2.5 text-left text-xs font-medium text-gray-400 uppercase tracking-wide border-b border-gray-800 whitespace-nowrap ${header.column.getCanSort() ? "cursor-pointer select-none hover:text-gray-200" : ""} ${(header.column.columnDef.meta as { className?: string })?.className ?? ""}`}
-                  onClick={header.column.getToggleSortingHandler()}
-                >
-                  <span className="inline-flex items-center gap-1">
-                    {flexRender(header.column.columnDef.header, header.getContext())}
-                    {header.column.getIsSorted() === "asc" && " ↑"}
-                    {header.column.getIsSorted() === "desc" && " ↓"}
-                  </span>
-                </th>
-              ))}
+              {hg.headers.map((header) => {
+                const sorted = header.column.getIsSorted();
+                const ariaSort = sorted === "asc" ? "ascending" : sorted === "desc" ? "descending" : header.column.getCanSort() ? "none" : undefined;
+                return (
+                  <th
+                    key={header.id}
+                    style={{ width: header.getSize() }}
+                    aria-sort={ariaSort}
+                    className={`sticky top-0 bg-gray-900 px-3 py-2.5 text-left text-xs font-medium text-gray-400 uppercase tracking-wide border-b border-gray-800 whitespace-nowrap ${header.column.getCanSort() ? "cursor-pointer select-none hover:text-gray-200" : ""} ${(header.column.columnDef.meta as { className?: string })?.className ?? ""}`}
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      {sorted === "asc" && <span aria-hidden="true"> ↑</span>}
+                      {sorted === "desc" && <span aria-hidden="true"> ↓</span>}
+                    </span>
+                  </th>
+                );
+              })}
             </tr>
           ))}
         </thead>
@@ -299,26 +325,28 @@ export default function GrantTable({
         </tbody>
       </table>
       <div className="flex items-center justify-between px-3 py-2.5 border-t border-gray-800 text-xs text-gray-500">
-        <span>
+        <span aria-live="polite" aria-atomic="true">
           {filtered.length === grants.length
             ? `${grants.length} grants`
             : `${filtered.length} of ${grants.length} grants`}
         </span>
         {pageCount > 1 && (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2" role="navigation" aria-label="Pagination">
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={safePage === 1}
+              aria-label="Previous page"
               className="px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             >
               ‹ Prev
             </button>
-            <span className="tabular-nums">
-              {safePage} / {pageCount}
+            <span className="tabular-nums" aria-live="polite" aria-atomic="true">
+              Page {safePage} of {pageCount}
             </span>
             <button
               onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
               disabled={safePage === pageCount}
+              aria-label="Next page"
               className="px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             >
               Next ›

--- a/ui/src/components/SummaryCards.tsx
+++ b/ui/src/components/SummaryCards.tsx
@@ -14,12 +14,12 @@ interface CardProps {
 
 function Card({ label, value, sub, icon, accent }: CardProps) {
   return (
-    <div className="card flex items-start gap-4">
-      <div className={`text-2xl p-2 rounded-lg ${accent}`}>{icon}</div>
+    <div className="card flex items-start gap-4" aria-label={sub ? `${label}: ${value}, ${sub}` : `${label}: ${value}`}>
+      <div className={`text-2xl p-2 rounded-lg ${accent}`} aria-hidden="true">{icon}</div>
       <div className="min-w-0">
         <p className="text-gray-400 text-xs font-medium uppercase tracking-wide">{label}</p>
-        <p className="text-2xl font-bold text-white mt-0.5">{value}</p>
-        {sub && <p className="text-gray-500 text-xs mt-0.5 truncate">{sub}</p>}
+        <p className="text-2xl font-bold text-white mt-0.5" aria-hidden="true">{value}</p>
+        {sub && <p className="text-gray-500 text-xs mt-0.5 truncate" aria-hidden="true">{sub}</p>}
       </div>
     </div>
   );


### PR DESCRIPTION
GrantTable:
- aria-label on <table>, aria-sort on sortable <th> elements
- DeadlineCell: "Urgent" badge (< 30 days) and "Soon" badge (< 90 days) alongside the date; color is no longer the only urgency signal
- ScoreCell: sr-only text "X out of Y, high/medium/low" for screen readers
- Watchlist/candidate buttons: aria-label + aria-pressed (replaced title-only)
- Pagination: role=navigation, aria-label on Prev/Next, aria-live on count

GrantDrawer:
- role=dialog, aria-modal=true, aria-labelledby=drawer-title on panel
- aria-hidden=true on backdrop
- Focus moves to close button when drawer opens
- Star/eye buttons: aria-label + aria-pressed (replaced title-only)
- Notes textarea: htmlFor/id pair so label is programmatically associated
- ScoreBadge: aria-label with numeric value + level (high/medium/low)

ChatPanel:
- role=dialog, aria-modal=true on panel; aria-hidden on backdrop
- role=log, aria-live=polite on messages container
- Typing indicator: role=status + sr-only "AI is typing..." text
- Send/Stop/Clear buttons: descriptive aria-label
- Textarea: aria-label="Message input"

Dashboard:
- Filter inputs: sr-only <label> elements + aria-label on inputs without visible labels (search, score, deadline date)
- Export and logout icon buttons: aria-label replacing title
- Profile modal: role=dialog + aria-modal=true

SummaryCards:
- Decorative emoji icons: aria-hidden=true
- Card div: aria-label combining label + value + sub for screen readers

https://claude.ai/code/session_01P59sK6Mdp5HW9HcaZBHoit