### PR TITLE
Fix CSV export — implement /data route and improve download handling

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -701,3 +701,51 @@ describe("POST /api/reset-password", () => {
     expect(res.status).toBe(400);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET /data — CSV export
+// ---------------------------------------------------------------------------
+
+describe("GET /data — CSV export", () => {
+  beforeEach(seedPrograms);
+
+  it("rejects unauthenticated requests with 401", async () => {
+    const res = await fetch(new Request("http://localhost/data"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns a CSV file with correct headers", async () => {
+    const { token } = await createAndLoginUser("csv1", "password1x");
+    const res = await authedGet("/data", token);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/csv");
+    const disposition = res.headers.get("content-disposition") ?? "";
+    expect(disposition).toContain("attachment");
+    expect(disposition).toContain(".csv");
+  });
+
+  it("returns all rows as valid CSV", async () => {
+    const { token } = await createAndLoginUser("csv2", "password1x");
+    const res = await authedGet("/data", token);
+    const text = await res.text();
+    const lines = text.trim().split("\r\n");
+    // header + 3 data rows
+    expect(lines.length).toBe(4);
+    expect(lines[0]).toContain("Name");
+    const names = ["Grant Alpha", "Grant Beta", "Grant Gamma"];
+    for (const name of names) {
+      expect(lines.some((l) => l.includes(name))).toBe(true);
+    }
+  });
+
+  it("properly escapes values containing commas and quotes", async () => {
+    const { token } = await createAndLoginUser("csv3", "password1x");
+    await env.GRANT_MANAGER_DB.prepare(
+      `INSERT INTO programs ("Name","Sponsor","Relevance","Fit","Ease","Stack Required?","Cadence","Deadline / Next Cohort")
+       VALUES ('Grant, Tricky "One"', 'Sponsor', '1', '1', '1', 'No', 'Annual', NULL)`
+    ).run();
+    const res = await authedGet("/data", token);
+    const text = await res.text();
+    expect(text).toContain('"Grant, Tricky ""One"""');
+  });
+});

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -161,8 +161,13 @@ export async function exportCsv(): Promise<void> {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = "grants.csv";
+  // Prefer the server-supplied filename from Content-Disposition; fall back to a static name.
+  const disposition = res.headers.get("Content-Disposition") ?? "";
+  const match = disposition.match(/filename="([^"]+)"/);
+  a.download = match ? match[1] : "grants.csv";
+  document.body.appendChild(a);
   a.click();
+  document.body.removeChild(a);
   URL.revokeObjectURL(url);
 }
 

--- a/worker.js
+++ b/worker.js
@@ -548,6 +548,38 @@ export default {
       return jsonResponse(JSON.stringify({ ok: true }));
     }
 
+    if (url.pathname === "/data" && request.method === "GET") {
+      if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+      const columns = await getColumns(env.GRANT_MANAGER_DB);
+      if (columns.length === 0) {
+        return new Response("No data available", { status: 404 });
+      }
+      const { results: rows } = await env.GRANT_MANAGER_DB.prepare(
+        `SELECT ${columns.map((c) => `"${c}"`).join(",")} FROM programs`
+      ).all();
+
+      function csvCell(val) {
+        const s = val === null || val === undefined ? "" : String(val);
+        return s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")
+          ? `"${s.replace(/"/g, '""')}"`
+          : s;
+      }
+
+      const header = columns.map(csvCell).join(",");
+      const dataRows = rows.map((r) => columns.map((c) => csvCell(r[c])).join(","));
+      const csv = [header, ...dataRows].join("\r\n") + "\r\n";
+
+      const date = new Date().toISOString().slice(0, 10);
+      log("info", "csv_exported", { ...reqCtx, rowCount: rows.length });
+      return new Response(csv, {
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="grants-${date}.csv"`,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+
     if (url.pathname === "/logout") {
       const match = cookie.match(/session=([^;]+)/);
       if (match && env.USER_PROFILES) {


### PR DESCRIPTION
The /data route was missing from worker.js entirely, so the export button fetched the SPA's index.html instead of a CSV file.

worker.js: Add GET /data — requires auth, reads all columns from D1, serialises to RFC-4180 CSV (values containing commas, quotes, or newlines are double-quote escaped), responds with Content-Type text/csv and Content-Disposition attachment with a date-stamped filename.

api.ts: Parse the server-supplied filename from Content-Disposition so the download is named "grants-YYYY-MM-DD.csv". Also append the <a> element to the document body before clicking (required in some browsers) and remove it after.

tests: Four new tests covering 401 on unauth, correct response headers, all rows present, and RFC-4180 escaping of commas/quotes.

https://claude.ai/code/session_01P59sK6Mdp5HW9HcaZBHoit