### PR TITLE
Fix invalid workflow conditional on SIMPLER_GRANTS_API_KEY step

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -38,7 +38,6 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Set Simpler Grants API key
-        if: ${{ secrets.SIMPLER_GRANTS_API_KEY != '' }}
         run: echo "$SIMPLER_GRANTS_API_KEY" | npx wrangler secret put SIMPLER_GRANTS_API_KEY
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
secrets.X != '' is not valid in GitHub Actions if: expressions. Remove the condition entirely — wrangler secret put with an empty value is a no-op and won't break the deploy.

https://claude.ai/code/session_01P59sK6Mdp5HW9HcaZBHoit