### PR TITLE
Link AI chat grant references to their in-app grant pages

### DIFF
--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -1,13 +1,69 @@
-import { useRef, useState, useEffect, type KeyboardEvent } from "react";
+import { useRef, useState, useEffect, type KeyboardEvent, type ReactNode } from "react";
 import type { ChatMessage } from "../types";
 import { sendChat } from "../api";
 
 interface Props {
   open: boolean;
   onClose: () => void;
+  onGrantLink?: (name: string) => void;
 }
 
-function MessageBubble({ msg }: { msg: ChatMessage }) {
+// Extracts the grant name from an in-app link (/?grant=<name>), or null for external URLs.
+function grantNameFromUrl(href: string): string | null {
+  try {
+    const u = new URL(href, window.location.origin);
+    if (u.origin === window.location.origin) {
+      return u.searchParams.get("grant");
+    }
+  } catch {
+    // not a valid URL
+  }
+  return null;
+}
+
+// Minimal inline markdown: [text](url) links and **bold**. The AI is instructed
+// to cite grants as markdown links pointing back into this app.
+function renderInlineMarkdown(text: string, onGrantLink?: (name: string) => void): ReactNode[] {
+  const re = /\[([^\]]+)\]\(([^)\s]+)\)|\*\*([^*]+)\*\*/g;
+  const nodes: ReactNode[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    if (m.index > last) nodes.push(text.slice(last, m.index));
+    if (m[1] !== undefined) {
+      const label = m[1];
+      const href = m[2];
+      const grantName = grantNameFromUrl(href);
+      const inApp = grantName !== null && onGrantLink !== undefined;
+      nodes.push(
+        <a
+          key={nodes.length}
+          href={href}
+          className="text-brand-400 underline underline-offset-2 hover:text-brand-300"
+          target={inApp ? undefined : "_blank"}
+          rel={inApp ? undefined : "noopener noreferrer"}
+          onClick={
+            inApp
+              ? (e) => {
+                  e.preventDefault();
+                  onGrantLink(grantName);
+                }
+              : undefined
+          }
+        >
+          {label}
+        </a>
+      );
+    } else {
+      nodes.push(<strong key={nodes.length}>{m[3]}</strong>);
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+function MessageBubble({ msg, onGrantLink }: { msg: ChatMessage; onGrantLink?: (name: string) => void }) {
   const isUser = msg.role === "user";
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"} mb-3`}>
@@ -24,7 +80,7 @@ function MessageBubble({ msg }: { msg: ChatMessage }) {
         }`}
         style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
       >
-        {msg.content}
+        {isUser ? msg.content : renderInlineMarkdown(msg.content, onGrantLink)}
       </div>
     </div>
   );
@@ -43,7 +99,7 @@ function NoAiKeyBanner() {
   );
 }
 
-export default function ChatPanel({ open, onClose }: Props) {
+export default function ChatPanel({ open, onClose, onGrantLink }: Props) {
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
       role: "assistant",
@@ -204,7 +260,7 @@ export default function ChatPanel({ open, onClose }: Props) {
           className="flex-1 overflow-y-auto px-4 py-4"
         >
           {messages.map((msg, i) => (
-            <MessageBubble key={i} msg={msg} />
+            <MessageBubble key={i} msg={msg} onGrantLink={onGrantLink} />
           ))}
           {loading && messages[messages.length - 1]?.content === "" && (
             <div className="flex justify-start mb-3" aria-label="AI is typing" role="status">

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -59,7 +59,17 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
 
   useEffect(() => {
     fetchGrants()
-      .then(({ data, total }: PagedGrants) => { setGrants(data); setGrantsTotal(total); })
+      .then(({ data, total }: PagedGrants) => {
+        setGrants(data);
+        setGrantsTotal(total);
+        // Deep link: /?grant=<name> opens that grant's detail drawer
+        const linked = new URLSearchParams(window.location.search).get("grant");
+        if (linked) {
+          const target = linked.trim().toLowerCase();
+          const g = data.find((x) => String(x.Name).trim().toLowerCase() === target);
+          if (g) setSelectedGrant(g);
+        }
+      })
       .catch((e) => {
         if (e.message === "Unauthenticated") {
           onLogout();
@@ -112,6 +122,17 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
       return next;
     });
   }, []);
+
+  const openGrantByName = useCallback((name: string) => {
+    const target = name.trim().toLowerCase();
+    const g = grants.find((x) => String(x.Name).trim().toLowerCase() === target);
+    if (g) {
+      setSelectedGrant(g);
+    } else {
+      // Not in the loaded page of grants — surface the closest matches in the table
+      setFilters((f) => ({ ...f, search: name }));
+    }
+  }, [grants]);
 
   const handleGrantUpdated = useCallback((name: string, notes: string) => {
     setGrants((prev) =>
@@ -380,7 +401,7 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
       />
 
       {/* Chat panel */}
-      <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} />
+      <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} onGrantLink={openGrantByName} />
 
       {/* Profile modal */}
       {profileOpen && (

--- a/worker.js
+++ b/worker.js
@@ -528,6 +528,7 @@ export default {
 
         grantContext = combined.map(r =>
           `• ${r.Name} | ${r.Sponsor} | ${r.Type || ""} | ${r.Stage || ""}\n` +
+          `  Link: ${url.origin}/?grant=${encodeURIComponent(r.Name)}\n` +
           `  Deadline: ${r["Deadline / Next Cohort"] || "N/A"} | Relevance: ${r.Relevance} | Fit: ${r.Fit} | Ease: ${r.Ease}\n` +
           `  Benefits: ${r.Benefits || "N/A"}\n` +
           `  Eligibility: ${r["Eligibility (key conditions)"] || "N/A"}` +
@@ -540,7 +541,10 @@ export default {
       const systemPrompt =
         `You are a grant research assistant. The user has a database of ${totalCount} grant opportunities. ` +
         `Answer questions using the grant data below. Reference grants by name, compare opportunities, ` +
-        `highlight deadlines and eligibility. Be concise and specific.\n\n` +
+        `highlight deadlines and eligibility. Be concise and specific. ` +
+        `Every time you mention a grant, format its name as a markdown link to its page in this app ` +
+        `using the exact Link URL provided for that grant, e.g. [Grant Name](https://app/?grant=...). ` +
+        `Never invent URLs — only use the Link values from the grant data.\n\n` +
         (grantContext ? `GRANTS FROM DATABASE:\n${grantContext}` : "Could not load grant data.");
 
       const aiMessages = [{ role: "system", content: systemPrompt }, ...chatMessages];


### PR DESCRIPTION
- worker.js: include a per-grant app link (/?grant=<name>) in the AI context and instruct the model to cite grants as markdown links
- ChatPanel: render markdown links and bold in assistant messages; in-app grant links open the grant drawer instead of navigating
- Dashboard: resolve grant links by name to open the detail drawer, and support /?grant=<name> deep links on page load

https://claude.ai/code/session_01LxJAC45ejKHudNPhgHvFDV