### PR TITLE
Refactor admin upload into dedicated admin page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,16 +5,18 @@ import Dashboard from "./components/Dashboard";
 import ProfileSetup from "./components/ProfileSetup";
 import WelcomePage from "./components/WelcomePage";
 import ForgotPassword from "./components/ForgotPassword";
+import AdminPage from "./components/AdminPage";
 import { checkAuth, login, fetchProfile, saveProfile, fetchMe, fetchCsrfToken } from "./api";
 import type { UserProfile } from "./api";
 
-type AuthState = "loading" | "unauthenticated" | "signup" | "forgot-password" | "profile-setup" | "welcome" | "authenticated";
+type AuthState = "loading" | "unauthenticated" | "signup" | "forgot-password" | "profile-setup" | "welcome" | "authenticated" | "admin";
 
 export default function App() {
   const [auth, setAuth] = useState<AuthState>("loading");
   const [profileSaving, setProfileSaving] = useState(false);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [username, setUsername] = useState("");
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     checkAuth().then(async (ok) => {
@@ -27,6 +29,7 @@ export default function App() {
       const hasWeights = p && p.weights && typeof p.weights === "object";
       setProfile(p);
       setUsername(me?.username ?? "");
+      setIsAdmin(me?.isAdmin ?? false);
       setAuth(hasWeights ? "welcome" : "profile-setup");
     });
   }, []);
@@ -50,6 +53,7 @@ export default function App() {
     const hasWeights = p && p.weights && typeof p.weights === "object";
     setProfile(p);
     setUsername(me?.username ?? "");
+    setIsAdmin(me?.isAdmin ?? false);
     setAuth(hasWeights ? "welcome" : "profile-setup");
   }
 
@@ -141,10 +145,20 @@ export default function App() {
     );
   }
 
+  if (auth === "admin") {
+    return (
+      <AdminPage
+        isAdmin={isAdmin}
+        onBack={() => setAuth("authenticated")}
+      />
+    );
+  }
+
   return (
     <Dashboard
       onLogout={() => setAuth("unauthenticated")}
       onBackToProfile={profile ? () => setAuth("welcome") : undefined}
+      onGoToAdmin={isAdmin ? () => setAuth("admin") : undefined}
     />
   );
 }

--- a/ui/src/components/AdminPage.tsx
+++ b/ui/src/components/AdminPage.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import AdminUpload from "./AdminUpload";
+
+interface Props {
+  isAdmin: boolean;
+  onBack: () => void;
+}
+
+export default function AdminPage({ isAdmin, onBack }: Props) {
+  const [uploaded, setUploaded] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-gray-950 p-4 sm:p-8">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="flex items-center gap-4">
+          <button
+            onClick={onBack}
+            className="btn-ghost gap-1.5 px-2.5"
+            aria-label="Back to dashboard"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Dashboard
+          </button>
+          <h1 className="text-xl font-bold text-white">Admin</h1>
+        </div>
+
+        {!isAdmin ? (
+          <div className="bg-amber-900/30 border border-amber-700 text-amber-300 rounded-xl px-5 py-4 text-sm">
+            You don't have admin access. Contact the site administrator to request it.
+          </div>
+        ) : (
+          <>
+            <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
+              Grant data
+            </h2>
+            {uploaded && (
+              <div className="bg-green-900/30 border border-green-700 text-green-300 rounded-xl px-4 py-3 text-sm">
+                Grants updated. Return to the{" "}
+                <button onClick={onBack} className="underline hover:text-green-200">
+                  dashboard
+                </button>{" "}
+                to see the changes.
+              </div>
+            )}
+            <AdminUpload
+              open={true}
+              inline={true}
+              onClose={onBack}
+              onUploaded={() => setUploaded(true)}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/AdminUpload.tsx
+++ b/ui/src/components/AdminUpload.tsx
@@ -6,9 +6,11 @@ interface Props {
   open: boolean;
   onClose: () => void;
   onUploaded: () => void;
+  /** When true, render inline (no fixed overlay) */
+  inline?: boolean;
 }
 
-export default function AdminUpload({ open, onClose, onUploaded }: Props) {
+export default function AdminUpload({ open, onClose, onUploaded, inline }: Props) {
   const [file, setFile] = useState<File | null>(null);
   const [mode, setMode] = useState<"merge" | "replace">("merge");
   const [uploading, setUploading] = useState(false);
@@ -55,6 +57,111 @@ export default function AdminUpload({ open, onClose, onUploaded }: Props) {
     }
   }
 
+  const cardContent = (
+    <>
+      {!inline && (
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-white">Upload grants CSV</h2>
+          <button onClick={handleClose} className="btn-ghost px-2" aria-label="Close">
+            ✕
+          </button>
+        </div>
+      )}
+
+      <p className="text-sm text-gray-400">
+        Add grants in bulk from a CSV file. The header row must include a{" "}
+        <code className="text-gray-300">Name</code> column; other recognized columns
+        (Type, Sponsor, Source URL, Deadline / Next Cohort, Benefits, Relevance, Fit,
+        Ease, …) are matched automatically and unknown columns are ignored.
+      </p>
+
+      <div className="space-y-3">
+        <div>
+          <label htmlFor="admin-csv-file" className="block text-sm text-gray-300 mb-1">
+            CSV file
+          </label>
+          <input
+            id="admin-csv-file"
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            className="input"
+            onChange={(e) => {
+              setFile(e.target.files?.[0] ?? null);
+              setError("");
+              setResult(null);
+            }}
+          />
+        </div>
+
+        <fieldset className="space-y-1.5">
+          <legend className="text-sm text-gray-300 mb-1">Import mode</legend>
+          <label className="flex items-start gap-2 text-sm text-gray-300 cursor-pointer">
+            <input
+              type="radio"
+              name="upload-mode"
+              checked={mode === "merge"}
+              onChange={() => setMode("merge")}
+              className="mt-0.5"
+            />
+            <span>
+              <strong>Merge</strong> — add new grants and update existing ones (matched by Name)
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-sm text-gray-300 cursor-pointer">
+            <input
+              type="radio"
+              name="upload-mode"
+              checked={mode === "replace"}
+              onChange={() => setMode("replace")}
+              className="mt-0.5"
+            />
+            <span>
+              <strong className="text-red-300">Replace</strong> — delete all existing grants,
+              then import the file
+            </span>
+          </label>
+        </fieldset>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/30 border border-red-700 text-red-300 rounded-xl px-4 py-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="bg-green-900/30 border border-green-700 text-green-300 rounded-xl px-4 py-3 text-sm space-y-1">
+          <p>
+            <strong>Import complete:</strong> {result.inserted} added
+            {result.mode === "merge" && <>, {result.updated} updated</>}
+            {result.skipped > 0 && <>, {result.skipped} skipped (missing Name)</>}.
+          </p>
+          {result.unknownColumns.length > 0 && (
+            <p className="text-green-400/80">
+              Ignored unrecognized columns: {result.unknownColumns.join(", ")}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 pt-1">
+        {!inline && (
+          <button onClick={handleClose} className="btn-outline" disabled={uploading}>
+            {result ? "Done" : "Cancel"}
+          </button>
+        )}
+        <button onClick={handleUpload} className="btn-primary" disabled={uploading || !file}>
+          {uploading ? "Uploading…" : "Upload"}
+        </button>
+      </div>
+    </>
+  );
+
+  if (inline) {
+    return <div className="card w-full max-w-lg space-y-4">{cardContent}</div>;
+  }
+
   return (
     <div
       role="dialog"
@@ -62,100 +169,7 @@ export default function AdminUpload({ open, onClose, onUploaded }: Props) {
       aria-label="Admin: upload grants CSV"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
     >
-      <div className="card w-full max-w-lg space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold text-white">Upload grants CSV</h2>
-          <button onClick={handleClose} className="btn-ghost px-2" aria-label="Close">
-            ✕
-          </button>
-        </div>
-
-        <p className="text-sm text-gray-400">
-          Add grants in bulk from a CSV file. The header row must include a{" "}
-          <code className="text-gray-300">Name</code> column; other recognized columns
-          (Type, Sponsor, Source URL, Deadline / Next Cohort, Benefits, Relevance, Fit,
-          Ease, …) are matched automatically and unknown columns are ignored.
-        </p>
-
-        <div className="space-y-3">
-          <div>
-            <label htmlFor="admin-csv-file" className="block text-sm text-gray-300 mb-1">
-              CSV file
-            </label>
-            <input
-              id="admin-csv-file"
-              ref={fileInputRef}
-              type="file"
-              accept=".csv,text/csv"
-              className="input"
-              onChange={(e) => {
-                setFile(e.target.files?.[0] ?? null);
-                setError("");
-                setResult(null);
-              }}
-            />
-          </div>
-
-          <fieldset className="space-y-1.5">
-            <legend className="text-sm text-gray-300 mb-1">Import mode</legend>
-            <label className="flex items-start gap-2 text-sm text-gray-300 cursor-pointer">
-              <input
-                type="radio"
-                name="upload-mode"
-                checked={mode === "merge"}
-                onChange={() => setMode("merge")}
-                className="mt-0.5"
-              />
-              <span>
-                <strong>Merge</strong> — add new grants and update existing ones (matched by Name)
-              </span>
-            </label>
-            <label className="flex items-start gap-2 text-sm text-gray-300 cursor-pointer">
-              <input
-                type="radio"
-                name="upload-mode"
-                checked={mode === "replace"}
-                onChange={() => setMode("replace")}
-                className="mt-0.5"
-              />
-              <span>
-                <strong className="text-red-300">Replace</strong> — delete all existing grants,
-                then import the file
-              </span>
-            </label>
-          </fieldset>
-        </div>
-
-        {error && (
-          <div className="bg-red-900/30 border border-red-700 text-red-300 rounded-xl px-4 py-3 text-sm">
-            {error}
-          </div>
-        )}
-
-        {result && (
-          <div className="bg-green-900/30 border border-green-700 text-green-300 rounded-xl px-4 py-3 text-sm space-y-1">
-            <p>
-              <strong>Import complete:</strong> {result.inserted} added
-              {result.mode === "merge" && <>, {result.updated} updated</>}
-              {result.skipped > 0 && <>, {result.skipped} skipped (missing Name)</>}.
-            </p>
-            {result.unknownColumns.length > 0 && (
-              <p className="text-green-400/80">
-                Ignored unrecognized columns: {result.unknownColumns.join(", ")}
-              </p>
-            )}
-          </div>
-        )}
-
-        <div className="flex justify-end gap-2 pt-1">
-          <button onClick={handleClose} className="btn-outline" disabled={uploading}>
-            {result ? "Done" : "Cancel"}
-          </button>
-          <button onClick={handleUpload} className="btn-primary" disabled={uploading || !file}>
-            {uploading ? "Uploading…" : "Upload"}
-          </button>
-        </div>
-      </div>
+      <div className="card w-full max-w-lg space-y-4">{cardContent}</div>
     </div>
   );
 }

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -9,7 +9,6 @@ import GrantTable from "./GrantTable";
 import GrantDrawer from "./GrantDrawer";
 import ChatPanel from "./ChatPanel";
 import ProfileSetup from "./ProfileSetup";
-import AdminUpload from "./AdminUpload";
 
 const WATCHLIST_KEY = "gm_watchlist";
 const CANDIDATES_KEY = "gm_candidates";
@@ -30,6 +29,7 @@ function saveSet(key: string, s: Set<string>) {
 interface Props {
   onLogout: () => void;
   onBackToProfile?: () => void;
+  onGoToAdmin?: () => void;
 }
 
 const INITIAL_FILTERS: FilterState = {
@@ -41,7 +41,7 @@ const INITIAL_FILTERS: FilterState = {
   savedOnly: false,
 };
 
-export default function Dashboard({ onLogout, onBackToProfile }: Props) {
+export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Props) {
   const [grants, setGrants] = useState<Grant[]>([]);
   const [grantsTotal, setGrantsTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -58,7 +58,6 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
   const [candidates, setCandidates] = useState<Set<string>>(() => loadSet(CANDIDATES_KEY));
   const [liveSearchOpen, setLiveSearchOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [adminUploadOpen, setAdminUploadOpen] = useState(false);
 
   useEffect(() => {
     fetchGrants()
@@ -85,15 +84,7 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
     fetchMe().then((me) => setIsAdmin(me?.isAdmin ?? false)).catch(() => {});
   }, [onLogout]);
 
-  const reloadGrants = useCallback(async () => {
-    try {
-      const { data, total } = await fetchGrants();
-      setGrants(data);
-      setGrantsTotal(total);
-    } catch {
-      // keep the current table on refresh failure
-    }
-  }, []);
+
 
   async function handleProfileSave(p: UserProfile) {
     setProfileSaving(true);
@@ -198,16 +189,17 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
             </button>
           )}
 
-          {isAdmin && (
+          {isAdmin && onGoToAdmin && (
             <button
-              onClick={() => setAdminUploadOpen(true)}
-              className="btn-outline hidden sm:flex gap-1.5 border-amber-700 text-amber-300 hover:bg-amber-900/30"
-              aria-label="Admin: upload grants CSV"
+              onClick={onGoToAdmin}
+              className="btn-outline gap-1.5 border-amber-700 text-amber-300 hover:bg-amber-900/30"
+              aria-label="Admin panel"
             >
               <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-              Upload CSV
+              Admin
             </button>
           )}
 
@@ -429,13 +421,6 @@ export default function Dashboard({ onLogout, onBackToProfile }: Props) {
 
       {/* Chat panel */}
       <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} onGrantLink={openGrantByName} />
-
-      {/* Admin CSV upload */}
-      <AdminUpload
-        open={adminUploadOpen}
-        onClose={() => setAdminUploadOpen(false)}
-        onUploaded={reloadGrants}
-      />
 
       {/* Profile modal */}
       {profileOpen && (

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,7 +11,7 @@ command = "cd ui && npm install && npm run build"
 [vars]
 # Comma-separated usernames allowed to use admin features (CSV grant upload).
 # Defaults to "demo" when unset.
-ADMIN_USERS = "demo"
+ADMIN_USERS = "demo,asialakay"
 
 [[kv_namespaces]]
 binding = "USER_PROFILES"


### PR DESCRIPTION
## Summary
Extracted the admin CSV upload functionality from the Dashboard into a dedicated AdminPage component, improving separation of concerns and enabling a more focused admin interface.

## Key Changes
- **New AdminPage component** (`ui/src/components/AdminPage.tsx`): Dedicated page for admin operations with access control, featuring the inline upload form and status messaging
- **Refactored AdminUpload component**: Added `inline` prop to support rendering without the modal overlay, allowing flexible usage in both modal and page contexts
- **Updated Dashboard**: Removed embedded admin upload modal and replaced with a navigation button that triggers the admin page
- **Updated App routing**: Added "admin" auth state to handle navigation to the new AdminPage component, with proper admin status tracking
- **Updated wrangler.toml**: Added "asialakay" to ADMIN_USERS configuration

## Implementation Details
- The AdminUpload component now conditionally renders its header and close button based on the `inline` prop, reducing code duplication
- Admin page includes access control messaging for non-admin users
- Success feedback is displayed inline after upload completion with a link back to the dashboard
- The admin button in Dashboard is now always visible (when admin) rather than hidden on small screens, with updated icon (settings gear instead of upload)
- Admin state is properly tracked and passed through the component hierarchy for consistent access control

https://claude.ai/code/session_01VdUQekArH9xiUaDqgXKK5J