### PR TITLE
Fix blank page on first load caused by cached stale index.html

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -881,7 +881,17 @@ export default {
     const assetRes = await env.ASSETS.fetch(request);
     const newHeaders = new Headers(assetRes.headers);
     newHeaders.set("X-Content-Type-Options", "nosniff");
-    newHeaders.set("Cache-Control", "public, max-age=86400");
+    const assetType = assetRes.headers.get("content-type") || "";
+    if (assetType.includes("text/html")) {
+      // Never cache HTML: a stale index.html references hashed bundles that
+      // vanish on the next deploy, leaving users a blank page until refresh.
+      newHeaders.set("Cache-Control", "no-cache");
+    } else if (url.pathname.startsWith("/assets/")) {
+      // Vite content-hashes bundle filenames, so these are safe to cache hard.
+      newHeaders.set("Cache-Control", "public, max-age=31536000, immutable");
+    } else {
+      newHeaders.set("Cache-Control", "public, max-age=86400");
+    }
     return new Response(assetRes.body, { status: assetRes.status, headers: newHeaders });
   },
 };


### PR DESCRIPTION
The worker stamped Cache-Control: public, max-age=86400 on every static asset response, including index.html. After a deploy, browsers within the 24h window served the cached HTML, which references content-hashed JS bundles that no longer exist; the SPA fallback returned HTML for the missing bundle and nosniff blocked execution, leaving a blank page until a manual refresh revalidated the document.

Serve HTML with no-cache so it revalidates on every visit, and cache the content-hashed /assets/ bundles as immutable for a year.

https://claude.ai/code/session_01VdUQekArH9xiUaDqgXKK5J