### PR TITLE
Update demo access instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 **[https://grant-manager-tool-demo.asialakaygrady-6d4.workers.dev](https://grant-manager-tool-demo.asialakaygrady-6d4.workers.dev)**
 
-603 non-dilutive grants loaded, personalized scoring live. Access credentials available on request.
+603 non-dilutive grants loaded, personalized scoring live.
+
+> **Demo login:** username `demo` · password `demo`
 
 ---
 
@@ -68,7 +70,7 @@ A full data pipeline runs from Grants.gov API search through normalization, scor
 
 **[View the live dashboard →](https://grant-manager-tool-demo.asialakaygrady-6d4.workers.dev)**
 
-Access credentials available on request.
+> **Demo login:** username `demo` · password `demo`
 
 ---
 
@@ -213,7 +215,7 @@ This tool was built on personal time, with no institutional support. The IP belo
 
 This repository is source-available for evaluation purposes. Licensing inquiries welcome.
 
-For access credentials, partnership discussions, or licensing: [LinkedIn](https://www.linkedin.com/in/asia-lakay-grady/)
+For partnership discussions or licensing: [LinkedIn](https://www.linkedin.com/in/asia-lakay-grady/)
 
 ---
 


### PR DESCRIPTION
## Summary
Updated the README documentation to provide explicit demo login credentials instead of requiring users to request access separately.

## Key Changes
- Added demo login credentials (username: `demo`, password: `demo`) in two prominent locations:
  - In the introductory section below the demo link
  - In the "Getting Started" section
- Removed the phrase "Access credentials available on request" from the introduction
- Simplified the contact section to focus on partnership discussions and licensing inquiries, removing the separate mention of access credentials

## Rationale
This change improves the user experience by making it immediately clear how to access the demo without requiring an additional request step. The credentials are now self-service and prominently displayed for new users.

https://claude.ai/code/session_01DskSa6uQMCsQGzFZcJvAZc