### PR TITLE
Fix live search source links to point to correct Simpler Grants.gov o…

### DIFF
--- a/unified_worker_engine.js
+++ b/unified_worker_engine.js
@@ -415,7 +415,7 @@ async function syncGrantsWithD1(env, query) {
     const name = opp.opportunity_title || summary.opportunity_title || "Untitled Grant";
     const type = capitalize(opp.funding_instrument || summary.funding_instruments?.[0] || "grant");
     const sponsor = opp.agency_name || summary.agency_name || opp.agency_code || "Unknown Agency";
-    const sourceUrl = opp.opportunity_id ? `https://grants.gov/search-results-detail/${opp.opportunity_id}` : "";
+    const sourceUrl = (opp.opportunity_number || opp.opportunity_id) ? `https://simpler.grants.gov/opportunities/${opp.opportunity_number || opp.opportunity_id}` : "";
     const deadline = opp.close_date || summary.close_date || "";
     const benefits = fmtAward(opp.award_floor ?? summary.award_floor, opp.award_ceiling ?? summary.award_ceiling);
     const eligibility = Array.isArray(opp.applicant_types)
@@ -729,7 +729,7 @@ export default {
           type: capitalize(opp.funding_instrument || summary.funding_instruments?.[0] || "grant"),
           name: titleName,
           sponsor: sponsorName,
-          source_url: opp.opportunity_id ? `https://grants.gov/search-results-detail/${opp.opportunity_id}` : "",
+          source_url: (opp.opportunity_number || opp.opportunity_id) ? `https://simpler.grants.gov/opportunities/${opp.opportunity_number || opp.opportunity_id}` : "",
           region_eligibility: "",
           deadline: deadlineDate,
           cadence: "",

--- a/worker.js
+++ b/worker.js
@@ -648,8 +648,8 @@ export default {
           "Type": capitalize(opp.funding_instrument || summary.funding_instruments?.[0] || "grant"),
           "Name": opp.opportunity_title || summary.opportunity_title || "",
           "Sponsor": opp.agency_name || summary.agency_name || opp.agency_code || "",
-          "Source URL": opp.opportunity_id
-            ? `https://simpler.grants.gov/opportunities/${opp.opportunity_id}`
+          "Source URL": (opp.opportunity_number || opp.opportunity_id)
+            ? `https://simpler.grants.gov/opportunities/${opp.opportunity_number || opp.opportunity_id}`
             : "",
           "Region/Eligibility": "",
           "Deadline/Next Cohort": opp.close_date || summary.close_date || "",

--- a/worker.js
+++ b/worker.js
@@ -649,7 +649,7 @@ export default {
           "Name": opp.opportunity_title || summary.opportunity_title || "",
           "Sponsor": opp.agency_name || summary.agency_name || opp.agency_code || "",
           "Source URL": opp.opportunity_id
-            ? `https://grants.gov/search-results-detail/${opp.opportunity_id}`
+            ? `https://simpler.grants.gov/opportunities/${opp.opportunity_id}`
             : "",
           "Region/Eligibility": "",
           "Deadline/Next Cohort": opp.close_date || summary.close_date || "",


### PR DESCRIPTION
…pportunity pages

Was using grants.gov/search-results-detail/{id} (generic/broken) — correct URL is simpler.grants.gov/opportunities/{id} to match the API source.

https://claude.ai/code/session_01V5t5NCRvfroZXUFgjYiDUo