### PR TITLE
Fix live search source URLs: use numeric opportunity_id not opportuni…

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -716,8 +716,8 @@ export default {
           "Type": capitalize(opp.funding_instrument || summary.funding_instruments?.[0] || "grant"),
           "Name": opp.opportunity_title || summary.opportunity_title || "",
           "Sponsor": opp.agency_name || summary.agency_name || opp.agency_code || "",
-          "Source URL": (opp.opportunity_number || opp.opportunity_id)
-            ? `https://simpler.grants.gov/opportunities/${opp.opportunity_number || opp.opportunity_id}`
+          "Source URL": opp.opportunity_id
+            ? `https://grants.gov/search-results-detail/${opp.opportunity_id}`
             : "",
           "Region/Eligibility": "",
           "Deadline/Next Cohort": opp.close_date || summary.close_date || "",


### PR DESCRIPTION
…ty_number

opportunity_number is a human-readable text ID (e.g. HHS-2024-ACL-0011) and is not a valid path segment on grants.gov. Switched to the numeric opportunity_id which grants.gov/search-results-detail/ actually expects.

https://claude.ai/code/session_01BRysWNr9iPWt96oNHoNbwz