### PR TITLE
ci: apply D1 migrations before deploy

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -22,9 +22,16 @@ jobs:
         working-directory: ui
         run: npm ci && npm run build
 
+      - name: Apply D1 migrations
+        working-directory: .
+        run: npm ci && npx wrangler d1 migrations apply grant-manager-db --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy main worker
         working-directory: .
-        run: npm ci && npx wrangler deploy
+        run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Adds a `wrangler d1 migrations apply --remote` step before the Worker deploy so the `feedback` and `subscribers` tables are created in D1 before the new route goes live.

This fixes the "Submission failed" error on `POST /api/feedback`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011NncszPjXmb8HWtjrBHDv5)_