### PR TITLE
fix: fetch CSRF token after signup so profile save is not rejected

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -38,6 +38,7 @@ export default function App() {
   async function handleSignupSuccess(user: string, password: string) {
     try {
       await login(user, password);
+      await fetchCsrfToken();
       setUsername(user);
       setAuth("profile-setup");
     } catch {


### PR DESCRIPTION
After signup the user was automatically logged in but fetchCsrfToken()
was never called. The module-level _csrfToken stayed null, so the
subsequent POST to /api/profile was sent without X-CSRF-Token and the
worker returned 403. The error was silently swallowed, making signup
appear to succeed while the profile was never persisted — causing the
user to loop back to profile-setup on every subsequent login.