### PR TITLE
Add auto password suggestion on signup and password reset

### DIFF
--- a/ui/src/components/ForgotPassword.tsx
+++ b/ui/src/components/ForgotPassword.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from "react";
 import { requestPasswordReset, resetPassword } from "../api";
+import { generatePassword } from "../utils/generatePassword";
 
 interface Props {
   onBack: () => void;
@@ -15,6 +16,23 @@ export default function ForgotPassword({ onBack, onSuccess }: Props) {
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [suggestedPassword, setSuggestedPassword] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  function handleSuggest() {
+    const p = generatePassword();
+    setPassword(p);
+    setConfirmPassword(p);
+    setSuggestedPassword(p);
+    setCopied(false);
+  }
+
+  async function handleCopy() {
+    if (!suggestedPassword) return;
+    await navigator.clipboard.writeText(suggestedPassword);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
 
   async function handleRequest(e: FormEvent) {
     e.preventDefault();
@@ -112,13 +130,22 @@ export default function ForgotPassword({ onBack, onSuccess }: Props) {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">New Password</label>
+              <div className="flex items-center justify-between mb-1.5">
+                <label className="text-sm font-medium text-gray-300">New Password</label>
+                <button
+                  type="button"
+                  onClick={handleSuggest}
+                  className="text-xs text-brand-400 hover:text-brand-300 underline"
+                >
+                  Suggest strong password
+                </button>
+              </div>
               <input
                 className="input"
                 type="password"
                 autoComplete="new-password"
                 value={password}
-                onChange={(e) => setPassword(e.target.value)}
+                onChange={(e) => { setPassword(e.target.value); setSuggestedPassword(null); }}
                 required
                 minLength={8}
               />
@@ -131,10 +158,27 @@ export default function ForgotPassword({ onBack, onSuccess }: Props) {
                 type="password"
                 autoComplete="new-password"
                 value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
+                onChange={(e) => { setConfirmPassword(e.target.value); setSuggestedPassword(null); }}
                 required
               />
             </div>
+
+            {suggestedPassword && (
+              <div className="bg-green-900/30 border border-green-700 rounded-lg px-3 py-2.5 space-y-1.5">
+                <p className="text-green-300 text-xs font-medium">Suggested password — save this before continuing:</p>
+                <div className="flex items-center gap-2">
+                  <code className="text-green-200 text-sm font-mono break-all flex-1 select-all">{suggestedPassword}</code>
+                  <button
+                    type="button"
+                    onClick={handleCopy}
+                    className="shrink-0 text-xs text-green-300 hover:text-green-100 border border-green-700 hover:border-green-500 rounded px-2 py-1 transition-colors"
+                  >
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
+                <p className="text-green-500 text-xs">Both password fields have been filled. Store this in a password manager.</p>
+              </div>
+            )}
             <button type="submit" disabled={loading} className="btn-primary w-full justify-center py-2.5">
               {loading ? (
                 <>

--- a/ui/src/components/Signup.tsx
+++ b/ui/src/components/Signup.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from "react";
 import { signup } from "../api";
+import { generatePassword } from "../utils/generatePassword";
 
 interface Props {
   onSuccess: (username: string, password: string) => void;
@@ -12,6 +13,23 @@ export default function Signup({ onSuccess, onBackToLogin }: Props) {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [suggestedPassword, setSuggestedPassword] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  function handleSuggest() {
+    const p = generatePassword();
+    setPassword(p);
+    setConfirmPassword(p);
+    setSuggestedPassword(p);
+    setCopied(false);
+  }
+
+  async function handleCopy() {
+    if (!suggestedPassword) return;
+    await navigator.clipboard.writeText(suggestedPassword);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -60,13 +78,22 @@ export default function Signup({ onSuccess, onBackToLogin }: Props) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">Password</label>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-sm font-medium text-gray-300">Password</label>
+              <button
+                type="button"
+                onClick={handleSuggest}
+                className="text-xs text-brand-400 hover:text-brand-300 underline"
+              >
+                Suggest strong password
+              </button>
+            </div>
             <input
               className="input"
               type="password"
               autoComplete="new-password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => { setPassword(e.target.value); setSuggestedPassword(null); }}
               required
               minLength={8}
             />
@@ -80,10 +107,27 @@ export default function Signup({ onSuccess, onBackToLogin }: Props) {
               type="password"
               autoComplete="new-password"
               value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
+              onChange={(e) => { setConfirmPassword(e.target.value); setSuggestedPassword(null); }}
               required
             />
           </div>
+
+          {suggestedPassword && (
+            <div className="bg-green-900/30 border border-green-700 rounded-lg px-3 py-2.5 space-y-1.5">
+              <p className="text-green-300 text-xs font-medium">Suggested password — save this before continuing:</p>
+              <div className="flex items-center gap-2">
+                <code className="text-green-200 text-sm font-mono break-all flex-1 select-all">{suggestedPassword}</code>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="shrink-0 text-xs text-green-300 hover:text-green-100 border border-green-700 hover:border-green-500 rounded px-2 py-1 transition-colors"
+                >
+                  {copied ? "Copied!" : "Copy"}
+                </button>
+              </div>
+              <p className="text-green-500 text-xs">Both password fields have been filled. Store this in a password manager.</p>
+            </div>
+          )}
 
           <button
             type="submit"

--- a/ui/src/utils/generatePassword.ts
+++ b/ui/src/utils/generatePassword.ts
@@ -1,0 +1,27 @@
+const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const LOWER = "abcdefghijklmnopqrstuvwxyz";
+const DIGITS = "0123456789";
+const SYMBOLS = "!@#$%^&*-_=+?.";
+const ALL = UPPER + LOWER + DIGITS + SYMBOLS;
+
+function randInt(max: number): number {
+  const buf = new Uint32Array(1);
+  crypto.getRandomValues(buf);
+  return buf[0] % max;
+}
+
+export function generatePassword(length = 18): string {
+  const required = [
+    UPPER[randInt(UPPER.length)],
+    LOWER[randInt(LOWER.length)],
+    DIGITS[randInt(DIGITS.length)],
+    SYMBOLS[randInt(SYMBOLS.length)],
+  ];
+  const rest = Array.from({ length: length - required.length }, () => ALL[randInt(ALL.length)]);
+  const combined = [...required, ...rest];
+  for (let i = combined.length - 1; i > 0; i--) {
+    const j = randInt(i + 1);
+    [combined[i], combined[j]] = [combined[j], combined[i]];
+  }
+  return combined.join("");
+}


### PR DESCRIPTION
Adds a "Suggest strong password" button to the password fields on the signup form and the password-reset form. Clicking it generates an 18-character cryptographically random password (uppercase, lowercase, digits, symbols via crypto.getRandomValues), fills both password fields, and shows the password in plaintext with a one-click copy button so users can save it to a password manager before submitting.

https://claude.ai/code/session_01YaDnC6ZFr9sBoa6gdfP4jJ