### PR TITLE
Add error handling for login and CSRF validation

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -47,16 +47,20 @@ export default function App() {
   }
 
   async function handleLoginSuccess() {
-    const [p, me] = await Promise.all([
-      fetchProfile().catch(() => null),
-      fetchMe(),
-      fetchCsrfToken(),
-    ]);
-    const hasWeights = p && p.weights && typeof p.weights === "object";
-    setProfile(p);
-    setUsername(me?.username ?? "");
-    setIsAdmin(me?.isAdmin ?? false);
-    setAuth(hasWeights ? "welcome" : "profile-setup");
+    try {
+      const [p, me] = await Promise.all([
+        fetchProfile().catch(() => null),
+        fetchMe(),
+        fetchCsrfToken(),
+      ]);
+      const hasWeights = p && p.weights && typeof p.weights === "object";
+      setProfile(p);
+      setUsername(me?.username ?? "");
+      setIsAdmin(me?.isAdmin ?? false);
+      setAuth(hasWeights ? "welcome" : "profile-setup");
+    } catch {
+      setAuth("unauthenticated");
+    }
   }
 
   async function handleProfileSave(p: UserProfile) {

--- a/worker.js
+++ b/worker.js
@@ -345,10 +345,12 @@ async function resolveSession(env, cookie) {
 async function validateCsrf(request, env, username) {
   const token = request.headers.get("X-CSRF-Token");
   if (!token) return false;
-  const stored = env.USER_PROFILES
-    ? await env.USER_PROFILES.get(`csrf:${username}`)
-    : null;
-  return stored === token;
+  try {
+    const stored = env.USER_PROFILES
+      ? await env.USER_PROFILES.get(`csrf:${username}`)
+      : null;
+    return stored === token;
+  } catch { return false; }
 }
 
 async function checkRateLimit(kv, key) {


### PR DESCRIPTION
## Summary
This PR adds error handling to improve the robustness of authentication flows by gracefully handling failures during login and CSRF token validation.

## Key Changes
- **Login error handling**: Wrapped `handleLoginSuccess()` in a try-catch block to redirect users to the unauthenticated state if any of the async operations (profile fetch, user info fetch, or CSRF token fetch) fail
- **CSRF validation error handling**: Added try-catch to `validateCsrf()` to return `false` if the KV store operation fails, preventing unhandled exceptions during CSRF token validation

## Implementation Details
- When login fails, users are now redirected to the "unauthenticated" auth state instead of leaving the app in an inconsistent state
- CSRF validation failures are treated as invalid tokens, maintaining security posture while preventing crashes from storage layer issues
- Both changes follow a fail-safe approach appropriate for authentication-critical code paths

https://claude.ai/code/session_01RC3gKU7CGmMYQ3oqhiLHSo