### PR TITLE
fix: normalize usernames to lowercase on login and signup

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -521,7 +521,7 @@ async function handleRequest(request, env, ctx) {
       }
 
       const form = await request.formData();
-      const newUser = (form.get("username") || "").trim();
+      const newUser = (form.get("username") || "").trim().toLowerCase();
       const newPass = form.get("password") || "";
       const confirmPass = form.get("confirm_password") || "";
 
@@ -573,7 +573,7 @@ async function handleRequest(request, env, ctx) {
 
     if (url.pathname === "/login" && request.method === "POST") {
       const form = await request.formData();
-      const user = form.get("username");
+      const user = (form.get("username") || "").trim().toLowerCase();
       const pass = form.get("password");
       const ip = request.headers.get("CF-Connecting-IP") || "unknown";
 


### PR DESCRIPTION
'Demo' and 'demo' were treated as different users because the D1 lookup is case-sensitive. Now both login and signup lowercase the username so typing 'Demo' matches the stored 'demo' account.

https://claude.ai/code/session_01RC3gKU7CGmMYQ3oqhiLHSo