### PR TITLE
fix: use SHA-256 hash for demo account instead of PBKDF2

### DIFF
--- a/migrations/0007_fix_demo_password.sql
+++ b/migrations/0007_fix_demo_password.sql
@@ -3,6 +3,8 @@
 -- The hash in 0003 was a placeholder and did not match password "demo".
 -- This replaces it with a correctly-derived PBKDF2-HMAC-SHA256 hash for "demo".
 
+-- Use a legacy SHA-256 hash for the demo account (same format as all real user accounts).
+-- The PBKDF2 path seeded in 0003 was throwing a runtime error in Cloudflare Workers.
 UPDATE users
-SET password_hash = 'pbkdf2$600000$b7e3a1c9f4d2806e5a391b7c8d4f2e01$7fea5fc9c994f415dcaf55df110855b363fc83ce3bafb8ca0fa567a0888ef033'
+SET password_hash = '2a97516c354b68848cdbd8f54a226a0a55b21ed138e207ad6c5cbb9c00aa5aea'
 WHERE username = 'demo';


### PR DESCRIPTION
The PBKDF2 code path throws a runtime error in Cloudflare Workers (all real user accounts use legacy SHA-256 hashes and work fine). Using the same format for demo until the PBKDF2 issue is investigated.

https://claude.ai/code/session_01RC3gKU7CGmMYQ3oqhiLHSo