### PR TITLE
feat: mobile-first UI redesign

### DIFF
--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -229,7 +229,7 @@ export default function ChatPanel({ open, onClose, onGrantLink }: Props) {
         role="dialog"
         aria-modal="true"
         aria-label="AI Chat Assistant"
-        className={`fixed right-0 top-0 h-full w-full max-w-sm bg-gray-900 border-l border-gray-800 z-40 flex flex-col transition-transform duration-300 ease-out ${open ? "translate-x-0" : "translate-x-full"}`}
+        className={`fixed right-0 top-0 h-full w-full sm:max-w-sm bg-gray-900 sm:border-l border-gray-800 z-40 flex flex-col transition-transform duration-300 ease-out ${open ? "translate-x-0" : "translate-x-full"}`}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3.5 border-b border-gray-800">

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -58,6 +58,8 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
   const [candidates, setCandidates] = useState<Set<string>>(() => loadSet(CANDIDATES_KEY));
   const [liveSearchOpen, setLiveSearchOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   useEffect(() => {
     fetchGrants()
@@ -163,10 +165,10 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
   return (
     <div className="min-h-screen bg-gray-950 flex flex-col">
       {/* Topbar */}
-      <header className="bg-gray-900 border-b border-gray-800 px-4 lg:px-6 py-3 flex items-center justify-between gap-4 shrink-0">
-        <div className="flex items-center gap-3">
-          <span className="text-xl">💰</span>
-          <div>
+      <header className="bg-gray-900 border-b border-gray-800 px-4 lg:px-6 py-3 flex items-center justify-between gap-2 shrink-0">
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="text-xl shrink-0">💰</span>
+          <div className="min-w-0">
             <h1 className="text-base font-semibold text-white leading-tight">Grant Manager</h1>
             {!loading && (
               <p className="text-gray-500 text-xs">{grantsTotal} programs loaded</p>
@@ -174,7 +176,8 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5 shrink-0">
+          {/* Desktop-only action buttons */}
           {onBackToProfile && (
             <button
               onClick={onBackToProfile}
@@ -192,7 +195,7 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
           {isAdmin && onGoToAdmin && (
             <button
               onClick={onGoToAdmin}
-              className="btn-outline gap-1.5 border-amber-700 text-amber-300 hover:bg-amber-900/30"
+              className="btn-outline gap-1.5 hidden sm:flex border-amber-700 text-amber-300 hover:bg-amber-900/30"
               aria-label="Admin panel"
             >
               <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -226,9 +229,78 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
             Live Search
           </button>
 
+          {/* Mobile overflow menu */}
+          <div className="relative sm:hidden">
+            <button
+              onClick={() => setMobileMenuOpen((o) => !o)}
+              className="btn-ghost px-2.5"
+              aria-label="More options"
+              aria-expanded={mobileMenuOpen}
+              aria-haspopup="menu"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+              </svg>
+            </button>
+
+            {mobileMenuOpen && (
+              <>
+                <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => setMobileMenuOpen(false)} />
+                <div role="menu" className="absolute right-0 top-full mt-1 w-52 bg-gray-800 border border-gray-700 rounded-xl shadow-xl z-50 overflow-hidden py-1">
+                  {onBackToProfile && (
+                    <button
+                      role="menuitem"
+                      onClick={() => { onBackToProfile(); setMobileMenuOpen(false); }}
+                      className="w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-3 transition-colors"
+                    >
+                      <svg className="w-4 h-4 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z" />
+                      </svg>
+                      {profile ? "My Profile" : "Set profile"}
+                      {!profile && <span className="w-1.5 h-1.5 rounded-full bg-brand-400 ml-auto shrink-0" />}
+                    </button>
+                  )}
+                  {isAdmin && onGoToAdmin && (
+                    <button
+                      role="menuitem"
+                      onClick={() => { onGoToAdmin(); setMobileMenuOpen(false); }}
+                      className="w-full text-left px-4 py-3 text-sm text-amber-300 hover:bg-gray-700 flex items-center gap-3 transition-colors border-t border-gray-700/50"
+                    >
+                      <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      </svg>
+                      Admin Panel
+                    </button>
+                  )}
+                  <button
+                    role="menuitem"
+                    onClick={() => { handleExport(); setMobileMenuOpen(false); }}
+                    className="w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-3 transition-colors border-t border-gray-700/50"
+                  >
+                    <svg className="w-4 h-4 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                    Export CSV
+                  </button>
+                  <button
+                    role="menuitem"
+                    onClick={() => { setLiveSearchOpen((o) => !o); setMobileMenuOpen(false); }}
+                    className={`w-full text-left px-4 py-3 text-sm hover:bg-gray-700 flex items-center gap-3 transition-colors border-t border-gray-700/50 ${liveSearchOpen ? "text-green-300" : "text-gray-200"}`}
+                  >
+                    <svg className="w-4 h-4 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                    </svg>
+                    {liveSearchOpen ? "Hide Live Search" : "Live Search"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+
           <button
             onClick={() => setChatOpen(true)}
             className="btn-primary gap-1.5"
+            aria-label="Open AI chat"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
@@ -288,16 +360,29 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
                     </span>
                   )}
                 </h2>
-                {activeFilterCount > 0 && (
+                <div className="flex items-center gap-2">
+                  {activeFilterCount > 0 && (
+                    <button
+                      onClick={() => setFilters(INITIAL_FILTERS)}
+                      className="text-xs text-gray-400 hover:text-white transition-colors"
+                    >
+                      Clear all
+                    </button>
+                  )}
                   <button
-                    onClick={() => setFilters(INITIAL_FILTERS)}
-                    className="text-xs text-gray-400 hover:text-white transition-colors"
+                    onClick={() => setFiltersOpen((o) => !o)}
+                    className="sm:hidden p-1 text-gray-400 hover:text-white transition-colors touch-manipulation"
+                    aria-expanded={filtersOpen}
+                    aria-label={filtersOpen ? "Hide filters" : "Show filters"}
                   >
-                    Clear all
+                    <svg className={`w-4 h-4 transition-transform duration-200 ${filtersOpen ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
                   </button>
-                )}
+                </div>
               </div>
 
+              <div className={`${filtersOpen ? "block" : "hidden"} sm:block space-y-3`}>
               <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
                 <div className="col-span-2 sm:col-span-3 lg:col-span-1">
                   <label htmlFor="filter-search" className="sr-only">Search by name or sponsor</label>
@@ -379,6 +464,7 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
                   </button>
                 </div>
               )}
+              </div>
             </div>
 
             {/* Live Search */}

--- a/ui/src/components/GrantDrawer.tsx
+++ b/ui/src/components/GrantDrawer.tsx
@@ -108,10 +108,15 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
         aria-modal="true"
         aria-labelledby="drawer-title"
         aria-label={grant ? `Grant details: ${grant.Name}` : "Grant details"}
-        className={`fixed right-0 top-0 h-full w-full max-w-xl bg-gray-900 border-l border-gray-800 z-50 flex flex-col transition-transform duration-300 ease-out ${grant ? "translate-x-0" : "translate-x-full"}`}
+        className={`fixed z-50 bg-gray-900 border-gray-800 flex flex-col transition-transform duration-300 ease-out bottom-0 left-0 right-0 h-[90vh] rounded-t-2xl border-t sm:bottom-auto sm:left-auto sm:right-0 sm:top-0 sm:h-full sm:w-full sm:max-w-xl sm:rounded-none sm:border-t-0 sm:border-l ${grant ? "translate-y-0 sm:translate-x-0" : "translate-y-full sm:translate-y-0 sm:translate-x-full"}`}
       >
         {grant && (
           <>
+            {/* Drag handle (mobile only) */}
+            <div className="sm:hidden flex justify-center pt-3 pb-1 shrink-0" aria-hidden="true">
+              <div className="w-10 h-1 bg-gray-600 rounded-full" />
+            </div>
+
             {/* Header */}
             <div className="flex items-start justify-between p-5 border-b border-gray-800">
               <div className="flex-1 min-w-0 pr-4">

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -7,6 +7,14 @@
     box-sizing: border-box;
   }
 
+  html {
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    overscroll-behavior-y: none;
+  }
+
   ::-webkit-scrollbar {
     width: 6px;
     height: 6px;
@@ -25,7 +33,7 @@
 
 @layer components {
   .btn {
-    @apply inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 disabled:opacity-50 disabled:pointer-events-none;
+    @apply inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 disabled:opacity-50 disabled:pointer-events-none touch-manipulation;
   }
   .btn-primary {
     @apply btn bg-brand-600 hover:bg-brand-700 text-white;


### PR DESCRIPTION
- Header: add overflow menu (⋯) on mobile exposing Profile, Admin, Export CSV, and Live Search — previously hidden actions are now accessible on small screens
- Filters: collapsible on mobile with a chevron toggle; desktop keeps always-visible layout
- ChatPanel: full-screen on mobile (removes max-w-sm cap); desktop retains 384px panel
- GrantDrawer: bottom sheet on mobile (90vh, slides up, rounded top, drag handle); desktop keeps right-side panel behavior
- CSS: add touch-manipulation to .btn for snappier touch response; increase py to 2 for better tap targets; add -webkit-text-size-adjust and overscroll-behavior-y to prevent common mobile layout quirks

https://claude.ai/code/session_015aTxmeJZZn7i6kGXEq7Y7r