### PR TITLE
Show live Simpler Grants API results alongside DB grants on first load

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -326,6 +326,34 @@ export async function liveSearch(q: string, page = 1, pageSize = 25): Promise<Pa
   return handleResponse<PagedGrants & { configured: boolean }>(res);
 }
 
+const FOCUS_AREA_QUERIES: Record<string, string> = {
+  "Health & Medicine":         "health medicine clinical",
+  "Education & Workforce":     "education workforce training",
+  "Technology & Innovation":   "technology innovation research",
+  "Housing & Community":       "affordable housing community development",
+  "Environment & Climate":     "climate environment clean energy",
+  "Agriculture & Food":        "agriculture food rural",
+  "Social Services":           "social services community welfare",
+  "Arts & Humanities":         "arts humanities culture",
+  "International Development": "international development global",
+  "Veterans & Military":       "veterans military service members",
+  "Research & Science":        "research science scientific",
+  "Justice & Safety":          "justice safety equity law",
+};
+
+export async function fetchLiveGrantsForDashboard(focusAreas: string[]): Promise<Grant[]> {
+  const query = focusAreas.length > 0
+    ? (FOCUS_AREA_QUERIES[focusAreas[0]] ?? focusAreas[0])
+    : "federal grants nonprofit";
+  try {
+    const res = await liveSearch(query, 1, 15);
+    if (!res.configured) return [];
+    return res.data.map((g) => ({ ...g, source: "live" as const }));
+  } catch {
+    return [];
+  }
+}
+
 export async function fetchLiveSearchStatus(): Promise<boolean> {
   try {
     const res = await fetch(`${BASE}/api/live-search-status`, { credentials: "include" });

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { Grant, FilterState } from "../types";
-import { fetchGrants, logout, exportCsv, fetchProfile, saveProfile, fetchMe } from "../api";
+import { fetchGrants, logout, exportCsv, fetchProfile, saveProfile, fetchMe, fetchLiveGrantsForDashboard } from "../api";
 import type { PagedGrants } from "../api";
 import LiveSearch from "./LiveSearch";
 import type { UserProfile } from "../api";
@@ -57,20 +57,31 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
   const [watchlist, setWatchlist] = useState<Set<string>>(() => loadSet(WATCHLIST_KEY));
   const [candidates, setCandidates] = useState<Set<string>>(() => loadSet(CANDIDATES_KEY));
   const [liveSearchOpen, setLiveSearchOpen] = useState(false);
+  const [liveGrantCount, setLiveGrantCount] = useState(0);
   const [isAdmin, setIsAdmin] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
 
   useEffect(() => {
+    const profilePromise = fetchProfile().then((p) => { setProfile(p); return p; }).catch(() => null);
+
     fetchGrants()
-      .then(({ data, total }: PagedGrants) => {
-        setGrants(data);
-        setGrantsTotal(total);
+      .then(async ({ data, total }: PagedGrants) => {
+        const dbNames = new Set(data.map((g) => String(g.Name).trim().toLowerCase()));
+        const p = await profilePromise;
+        const liveGrants = await fetchLiveGrantsForDashboard(p?.focusAreas ?? []);
+        const newLive = liveGrants.filter(
+          (g) => !dbNames.has(String(g.Name).trim().toLowerCase())
+        );
+        setLiveGrantCount(newLive.length);
+        const merged = [...data, ...newLive];
+        setGrants(merged);
+        setGrantsTotal(total + newLive.length);
         // Deep link: /?grant=<name> opens that grant's detail drawer
         const linked = new URLSearchParams(window.location.search).get("grant");
         if (linked) {
           const target = linked.trim().toLowerCase();
-          const g = data.find((x) => String(x.Name).trim().toLowerCase() === target);
+          const g = merged.find((x) => String(x.Name).trim().toLowerCase() === target);
           if (g) setSelectedGrant(g);
         }
       })
@@ -82,7 +93,6 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
         }
       })
       .finally(() => setLoading(false));
-    fetchProfile().then(setProfile).catch(() => {});
     fetchMe().then((me) => setIsAdmin(me?.isAdmin ?? false)).catch(() => {});
   }, [onLogout]);
 
@@ -171,7 +181,14 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
           <div className="min-w-0">
             <h1 className="text-base font-semibold text-white leading-tight">Grant Manager</h1>
             {!loading && (
-              <p className="text-gray-500 text-xs">{grantsTotal} programs loaded</p>
+              <p className="text-gray-500 text-xs flex items-center gap-1.5">
+                {grantsTotal} programs loaded
+                {liveGrantCount > 0 && (
+                  <span className="badge bg-green-900/40 text-green-400 border border-green-800/50 text-[10px] px-1.5 py-0.5">
+                    +{liveGrantCount} live
+                  </span>
+                )}
+              </p>
             )}
           </div>
         </div>

--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -83,8 +83,11 @@ function GrantCard({ grant, isCandidate, isWatchlisted, onRowClick, onToggleCand
     >
       {/* Name + action buttons */}
       <div className="flex items-start justify-between gap-2">
-        <p className="font-medium text-white text-sm leading-snug line-clamp-2 flex-1 min-w-0">
+        <p className="font-medium text-white text-sm leading-snug line-clamp-2 flex-1 min-w-0 flex items-start gap-1.5 flex-wrap">
           {grant.Name}
+          {grant.source === "live" && (
+            <span className="badge bg-green-900/40 text-green-400 border border-green-800/50 text-[10px] px-1.5 py-0.5 shrink-0 mt-0.5">live</span>
+          )}
         </p>
         <div className="flex items-center shrink-0 -mt-0.5 -mr-1" onClick={(e) => e.stopPropagation()}>
           <button
@@ -173,8 +176,11 @@ export default function GrantTable({
       columnHelper.accessor("Name", {
         header: "Name",
         cell: (info) => (
-          <span className="font-medium text-white text-sm line-clamp-2 leading-snug">
+          <span className="font-medium text-white text-sm line-clamp-2 leading-snug flex items-start gap-1.5 flex-wrap">
             {info.getValue()}
+            {info.row.original.source === "live" && (
+              <span className="badge bg-green-900/40 text-green-400 border border-green-800/50 text-[10px] px-1.5 py-0.5 shrink-0 mt-0.5">live</span>
+            )}
           </span>
         ),
         size: 200,

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -17,6 +17,7 @@ export interface Grant {
   "Weighted Score": number | string;
   "Notes/Actions": string;
   score?: number;
+  source?: "live" | "db";
   [key: string]: string | number | undefined;
 }
 


### PR DESCRIPTION
Fetches up to 15 live grants from Simpler Grants API on dashboard mount,
using the user's first profile focus area as the query (or a default
query if no profile). Results are deduplicated against the DB, appended
to the list, and marked with a green "live" badge. A "+N live" chip
appears in the header count. Silently no-ops if the API key is not
configured.

https://claude.ai/code/session_01KQ1d3SjmAtnu1TEoBx7o85