### PR TITLE
Fix CSV column mapping for spaced/punctuated headers and boolean coer…

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -157,12 +157,23 @@ function normalizeHeader(h) {
 }
 
 // Aliases for column headers used in existing CSV exports that differ from DB column names.
+// normalizeHeader() strips whitespace but preserves slashes, dashes, parens, and ? so we
+// need explicit entries for headers like "Region / Eligibility" → "region/eligibility".
 const CSV_COLUMN_ALIASES = {
-  "grantname":   "name",
-  "easeofuse":   "ease",
-  "link":        "source_url",
-  "matchreq%":   "weighted_score",
-  "match%":      "weighted_score",
+  // Legacy export names
+  "grantname":                    "name",
+  "easeofuse":                    "ease",
+  "link":                         "source_url",
+  "matchreq%":                    "weighted_score",
+  "match%":                       "weighted_score",
+  // Standard CSV format with spaces/slashes/punctuation
+  "region/eligibility":           "region_eligibility",
+  "deadline/nextcohort":          "deadline",
+  "notes/actions":                "notes",
+  "eligibility(keyconditions)":   "eligibility_conditions",
+  "non-dilutive?":                "non_dilutive",
+  "stackrequired?":               "stack_required",
+  "weightedscore":                "weighted_score",
 };
 
 function resolveHeader(h) {
@@ -964,13 +975,22 @@ async function handleRequest(request, env, ctx) {
         }
       }
 
+      const BOOL_COLS = new Set(["non_dilutive", "stack_required"]);
+      function coerceBool(col, val) {
+        if (!BOOL_COLS.has(col)) return val;
+        const s = String(val ?? "").trim().toLowerCase();
+        if (s === "yes" || s === "true" || s === "1") return 1;
+        if (s === "no"  || s === "false" || s === "0") return 0;
+        return null;
+      }
+
       const insertCols = [...new Set(mapping.filter(Boolean))];
       const insertStmt = db.prepare(
         `INSERT INTO programs (${insertCols.join(",")})
          VALUES (${insertCols.map(() => "?").join(",")})`
       );
       const statements = [...byName.values()].map((r) =>
-        insertStmt.bind(...insertCols.map((c) => r[c] ?? ""))
+        insertStmt.bind(...insertCols.map((c) => coerceBool(c, r[c] ?? "")))
       );
       for (let i = 0; i < statements.length; i += 50) {
         await db.batch(statements.slice(i, i + 50));


### PR DESCRIPTION
…cion

- CSV_COLUMN_ALIASES: add entries for all standard headers whose normalized form doesn't match the DB column name due to preserved slashes, parens, dashes, or ?  (e.g. "Region / Eligibility" → "region/eligibility" ≠ "region_eligibility"; "Non-dilutive?" → "non-dilutive?" ≠ "non_dilutive")
- CSV upload: coerce "Yes"/"No" → 1/0 for non_dilutive and stack_required INTEGER columns instead of inserting the raw string
- DB: cleared region_eligibility and notes rows that stored the CSV column header name as data ("Region / Eligibility", "Notes / Actions") — set to NULL so the drawer shows "—" instead of the header string

https://claude.ai/code/session_01YX5tTpmJ2w8Y7fATXLY9ig