### PR TITLE
Default sort to deadline ascending so live results aren't buried

### DIFF
--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -138,7 +138,7 @@ export default function GrantTable({
   onToggleCandidate,
 }: Props) {
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "score", desc: true },
+    { id: "Deadline/Next Cohort", desc: false },
   ]);
   const [page, setPage] = useState(1);
 


### PR DESCRIPTION
Changes the initial sort from match score to closest deadline first. Grants with no deadline date sort to the bottom via the existing Infinity fallback. This also ensures live API results appear in context rather than appended at the end of the list.

https://claude.ai/code/session_01KQ1d3SjmAtnu1TEoBx7o85