### PR TITLE
Sort grants by match score descending, then by upcoming deadline ascending

### DIFF
--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -138,6 +138,7 @@ export default function GrantTable({
   onToggleCandidate,
 }: Props) {
   const [sorting, setSorting] = useState<SortingState>([
+    { id: "score", desc: true },
     { id: "Deadline/Next Cohort", desc: false },
   ]);
   const [page, setPage] = useState(1);


### PR DESCRIPTION
Primary sort is now match score (highest first) so best-fit grants appear at
the top; deadline serves as the tiebreaker so equally-scored grants surface
the most urgent opportunities first.

https://claude.ai/code/session_01Y4jqpQxP4SGwgjG9FmpFCD