### PR TITLE
Normalize grant match scores to 0–10 scale for consistent UI display

### DIFF
--- a/ui/src/components/GrantTable.tsx
+++ b/ui/src/components/GrantTable.tsx
@@ -121,7 +121,7 @@ function GrantCard({ grant, isCandidate, isWatchlisted, onRowClick, onToggleCand
         )}
         <DeadlineBadge value={grant["Deadline/Next Cohort"]} />
         <span className="ml-auto flex items-center gap-1 text-xs text-gray-400 shrink-0">
-          Match:&nbsp;<ScoreCell value={grant.score ?? grant["Weighted Score"] ?? 0} max={3} />
+          Match:&nbsp;<ScoreCell value={grant.score ?? grant["Weighted Score"] ?? 0} max={10} />
         </span>
       </div>
     </div>
@@ -232,25 +232,25 @@ export default function GrantTable({
       }),
       columnHelper.accessor("Relevance", {
         header: "Rel",
-        cell: (info) => <ScoreCell value={info.getValue()} max={3} />,
+        cell: (info) => <ScoreCell value={info.getValue()} max={10} />,
         size: 55,
         meta: { className: "hidden lg:table-cell" },
       }),
       columnHelper.accessor("Fit", {
         header: "Fit",
-        cell: (info) => <ScoreCell value={info.getValue()} max={3} />,
+        cell: (info) => <ScoreCell value={info.getValue()} max={10} />,
         size: 50,
         meta: { className: "hidden lg:table-cell" },
       }),
       columnHelper.accessor("Ease", {
         header: "Ease",
-        cell: (info) => <ScoreCell value={info.getValue()} max={3} />,
+        cell: (info) => <ScoreCell value={info.getValue()} max={10} />,
         size: 55,
         meta: { className: "hidden lg:table-cell" },
       }),
       columnHelper.accessor("score", {
         header: "Match ★",
-        cell: (info) => <ScoreCell value={info.getValue() ?? 0} max={3} />,
+        cell: (info) => <ScoreCell value={info.getValue() ?? 0} max={10} />,
         size: 65,
         sortingFn: (a, b) => {
           const sa = parseFloat(String(a.original.score ?? "0"));

--- a/unified_worker_engine.js
+++ b/unified_worker_engine.js
@@ -289,10 +289,18 @@ function computeScore(r, weights, profile) {
        + wn.StackAlignment * (stack * 3)
        + wn.CadenceRecency * (cadence * 3);
 
-  // Profile match bonus: up to +1.5 added on top of the 0-3 base score.
-  // Grants matching the user's focus areas, org type, and stage rank higher.
   const profileMatch = profile ? computeProfileMatch(r, profile) : 0;
-  return baseScore + profileMatch * 1.5;
+  const hasProfile = profile && (
+    (Array.isArray(profile.focusAreas) && profile.focusAreas.length) ||
+    profile.orgType || profile.stage
+  );
+
+  if (hasProfile) {
+    // Profile match (0–1) scaled to 0–10; base score (0–3) as tiebreaker scaled to 0–1.
+    return profileMatch * 10 + (baseScore / 3);
+  }
+  // No profile — scale 0–3 base score to 0–10 for consistent display.
+  return baseScore * (10 / 3);
 }
 
 const SESSION_TTL = 86400; // 24 hours in seconds

--- a/worker.js
+++ b/worker.js
@@ -312,7 +312,8 @@ function computeScore(r, weights, profile) {
     return Math.round((profileMatch * 10 + dbScore / 3) * 100) / 100;
   }
 
-  // No profile — rank purely by DB quality scores
+  // No profile — rank purely by DB quality scores (0–3), scaled to 0–10 to match the
+  // profile branch so ScoreCell and GrantDrawer thresholds are consistent.
   const w = weights || DEFAULT_WEIGHTS;
   const total = Object.values(w).reduce((a, b) => a + b, 0) || 1;
   return Math.round((
@@ -321,7 +322,7 @@ function computeScore(r, weights, profile) {
   + ((w.Ease           ?? 0) / total) * ease
   + ((w.StackAlignment ?? 0) / total) * (stack * 3)
   + ((w.CadenceRecency ?? 0) / total) * (cadence * 3)
-  ) * 100) / 100;
+  ) * (10 / 3) * 100) / 100;
 }
 
 // Computes heuristic Relevance, Fit, and Ease scores (0–3 each) for live search


### PR DESCRIPTION
## Summary
This PR normalizes grant match scores across the application to use a consistent 0–10 scale instead of the previous mixed 0–3 and 0–10 scales. This ensures uniform score display in the UI and makes threshold logic more predictable.

## Key Changes
- **Score computation logic**: Updated `computeScore()` in both `unified_worker_engine.js` and `worker.js` to return scores on a 0–10 scale:
  - When a user profile exists: profile match (0–1) is scaled to 0–10, with base score (0–3) scaled to 0–1 as a tiebreaker
  - When no profile exists: base score (0–3) is scaled to 0–10 using the factor `10/3`
  
- **UI updates**: Updated all `ScoreCell` component instances in `GrantTable.tsx` to use `max={10}` instead of `max={3}`:
  - Relevance, Fit, and Ease columns
  - Match score column
  - Grant card match display

## Implementation Details
- The scaling ensures that scores are comparable whether or not a user profile is present
- Profile-based scoring prioritizes profile match quality while using base score as a secondary sort criterion
- Non-profile scoring maintains the relative weighting of individual quality metrics (Relevance, Fit, Ease, etc.) while fitting them into the 0–10 range
- Comments clarify the scoring behavior for future maintainers

https://claude.ai/code/session_019t8bwm76Q5cuBv9aUWtj9N