### PR TITLE
Fix login page demo UX: remove credentials, style button, force onboa…

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -63,6 +63,19 @@ export default function App() {
     }
   }
 
+  async function handleDemoLoginSuccess() {
+    try {
+      const me = await fetchMe();
+      await fetchCsrfToken();
+      setProfile(null);
+      setUsername(me?.username ?? "");
+      setIsAdmin(me?.isAdmin ?? false);
+      setAuth("profile-setup");
+    } catch {
+      setAuth("unauthenticated");
+    }
+  }
+
   async function handleProfileSave(p: UserProfile) {
     setProfileSaving(true);
     try {
@@ -122,6 +135,7 @@ export default function App() {
     return (
       <Login
         onSuccess={handleLoginSuccess}
+        onDemoSuccess={handleDemoLoginSuccess}
         onSignUp={() => setAuth("signup")}
         onForgotPassword={() => setAuth("forgot-password")}
       />

--- a/ui/src/components/Login.tsx
+++ b/ui/src/components/Login.tsx
@@ -3,11 +3,12 @@ import { login } from "../api";
 
 interface Props {
   onSuccess: () => void;
+  onDemoSuccess: () => void;
   onSignUp: () => void;
   onForgotPassword: () => void;
 }
 
-export default function Login({ onSuccess, onSignUp, onForgotPassword }: Props) {
+export default function Login({ onSuccess, onDemoSuccess, onSignUp, onForgotPassword }: Props) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -32,7 +33,7 @@ export default function Login({ onSuccess, onSignUp, onForgotPassword }: Props) 
     setLoading(true);
     try {
       await login("demo", "demo");
-      onSuccess();
+      onDemoSuccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Demo login failed");
     } finally {
@@ -118,15 +119,11 @@ export default function Login({ onSuccess, onSignUp, onForgotPassword }: Props) 
             type="button"
             disabled={loading}
             onClick={handleTryDemo}
-            className="w-full flex items-center justify-center gap-2 rounded-lg border-2 border-green-500 bg-transparent hover:bg-green-500/10 text-green-400 text-sm font-medium py-2.5 transition-colors disabled:opacity-50"
+            className="w-full flex items-center justify-center gap-2 rounded-lg bg-green-600 hover:bg-green-500 text-white text-sm font-medium py-2.5 transition-colors disabled:opacity-50"
           >
             Try the demo
           </button>
         </form>
-
-        <p className="text-center text-gray-600 text-xs mt-3">
-          Demo account: <span className="font-mono text-gray-500">demo</span> / <span className="font-mono text-gray-500">demo</span>
-        </p>
 
         <p className="text-center text-gray-500 text-sm mt-4">
           Don't have an account?{" "}


### PR DESCRIPTION
…rding

- Remove "Demo account: demo / demo" text from login page
- Change "Try the demo" button to solid green with white text for visual parity with Sign in
- Add onDemoSuccess handler that always routes demo login to profile-setup with blank profile, so demo users land on the mission statement onboarding screen

https://claude.ai/code/session_01H6ej6jLf63p8S3fx2CWmk8