### PR TITLE
Login UX fixes + Grant Eligibility Simulator

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -63,6 +63,19 @@ export default function App() {
     }
   }
 
+  async function handleDemoLoginSuccess() {
+    try {
+      const me = await fetchMe();
+      await fetchCsrfToken();
+      setProfile(null);
+      setUsername(me?.username ?? "");
+      setIsAdmin(me?.isAdmin ?? false);
+      setAuth("profile-setup");
+    } catch {
+      setAuth("unauthenticated");
+    }
+  }
+
   async function handleProfileSave(p: UserProfile) {
     setProfileSaving(true);
     try {
@@ -122,6 +135,7 @@ export default function App() {
     return (
       <Login
         onSuccess={handleLoginSuccess}
+        onDemoSuccess={handleDemoLoginSuccess}
         onSignUp={() => setAuth("signup")}
         onForgotPassword={() => setAuth("forgot-password")}
       />

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -59,6 +59,7 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
   const [liveSearchOpen, setLiveSearchOpen] = useState(false);
   const [liveGrantCount, setLiveGrantCount] = useState(0);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [username, setUsername] = useState("");
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
 
@@ -93,7 +94,7 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
         }
       })
       .finally(() => setLoading(false));
-    fetchMe().then((me) => setIsAdmin(me?.isAdmin ?? false)).catch(() => {});
+    fetchMe().then((me) => { setIsAdmin(me?.isAdmin ?? false); setUsername(me?.username ?? ""); }).catch(() => {});
   }, [onLogout]);
 
 
@@ -523,6 +524,7 @@ export default function Dashboard({ onLogout, onBackToProfile, onGoToAdmin }: Pr
         onToggleWatchlist={toggleWatchlist}
         onToggleCandidate={toggleCandidate}
         profile={profile}
+        username={username}
       />
 
       {/* Chat panel */}

--- a/ui/src/components/EligibilitySimulator.tsx
+++ b/ui/src/components/EligibilitySimulator.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Grant } from "../types";
+import type { UserProfile } from "../api";
+import { ORG_TYPE_KEYWORDS, STAGE_KEYWORDS } from "../rankingKeywords";
+
+type EligibilityStatus = "pass" | "fail" | "unknown";
+
+interface EligibilityRequirement {
+  id: string;
+  text: string;
+  autoStatus: EligibilityStatus;
+}
+
+interface Props {
+  grant: Grant;
+  profile: UserProfile;
+  username: string;
+}
+
+const GEO_TERMS = ["us-based", "u.s.", "united states", "us citizen", "us resident", "domestic", "american"];
+
+function parseFragments(text: string): string[] {
+  if (!text || text.trim() === "" || text.trim() === "—") return [];
+  let parts: string[];
+  if (text.includes(";")) {
+    parts = text.split(";");
+  } else if (/[\n\r]/.test(text)) {
+    parts = text.split(/[\n\r]+/);
+  } else if (text.includes(",") && text.length > 60) {
+    parts = text.split(",");
+  } else {
+    parts = [text];
+  }
+  return parts
+    .map((p) => p.replace(/^[\s\-•·*\d.]+/, "").trim())
+    .filter((p) => p.length > 3);
+}
+
+function detectStatus(fragment: string, profile: UserProfile): EligibilityStatus {
+  const lower = fragment.toLowerCase();
+
+  if (GEO_TERMS.some((t) => lower.includes(t))) return "unknown";
+
+  // Nonprofit shorthand
+  if (lower.includes("nonprofit") || lower.includes("501(c)") || lower.includes("501c")) {
+    return profile.orgType.toLowerCase().includes("nonprofit") ? "pass" : "fail";
+  }
+
+  // Org type: check profile match first
+  const profileOrgKws = ORG_TYPE_KEYWORDS[profile.orgType] ?? [];
+  if (profileOrgKws.some((kw) => lower.includes(kw))) return "pass";
+
+  // Org type: check for exclusionary other-type mention
+  for (const [otherType, kws] of Object.entries(ORG_TYPE_KEYWORDS)) {
+    if (otherType === profile.orgType) continue;
+    if (kws.some((kw) => lower.includes(kw))) return "fail";
+  }
+
+  // Stage: profile match
+  const profileStageKws = STAGE_KEYWORDS[profile.stage] ?? [];
+  if (profileStageKws.some((kw) => lower.includes(kw))) return "pass";
+
+  // Stage mismatch is ambiguous — don't hard-fail
+  return "unknown";
+}
+
+function storageKey(grantName: string, username: string): string {
+  return `gm_eligibility:${encodeURIComponent(grantName)}:${encodeURIComponent(username)}`;
+}
+
+function loadStored(key: string): { overrides: Record<string, EligibilityStatus | null>; collapsed: boolean } {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return { overrides: {}, collapsed: false };
+    return JSON.parse(raw);
+  } catch {
+    return { overrides: {}, collapsed: false };
+  }
+}
+
+const OVERRIDE_CYCLE: (EligibilityStatus | null)[] = [null, "pass", "fail", "unknown"];
+
+function nextOverride(current: EligibilityStatus | null): EligibilityStatus | null {
+  const idx = OVERRIDE_CYCLE.indexOf(current);
+  return OVERRIDE_CYCLE[(idx + 1) % OVERRIDE_CYCLE.length];
+}
+
+const STATUS_ICON: Record<EligibilityStatus, string> = { pass: "✓", fail: "✗", unknown: "?" };
+const STATUS_COLOR: Record<EligibilityStatus, string> = {
+  pass: "text-green-400",
+  fail: "text-red-400",
+  unknown: "text-gray-400",
+};
+const STATUS_BADGE: Record<EligibilityStatus, string> = {
+  pass: "bg-green-900/40 text-green-300",
+  fail: "bg-red-900/40 text-red-300",
+  unknown: "bg-gray-800 text-gray-400",
+};
+const STATUS_LABEL: Record<EligibilityStatus, string> = { pass: "Pass", fail: "Fail", unknown: "?" };
+
+export default function EligibilitySimulator({ grant, profile, username }: Props) {
+  const key = storageKey(String(grant.Name), username);
+
+  const requirements = useMemo<EligibilityRequirement[]>(() => {
+    const raw = String(grant["Eligibility (key conditions)"] || "");
+    return parseFragments(raw).map((text, i) => ({
+      id: `req-${i}`,
+      text,
+      autoStatus: detectStatus(text, profile),
+    }));
+  }, [grant.Name, profile]);
+
+  const [overrides, setOverrides] = useState<Record<string, EligibilityStatus | null>>({});
+  const [collapsed, setCollapsed] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  // Load from localStorage when grant changes
+  useEffect(() => {
+    const stored = loadStored(key);
+    setOverrides(stored.overrides);
+    setCollapsed(stored.collapsed);
+    setLoaded(true);
+  }, [key]);
+
+  // Save on changes (after initial load)
+  useEffect(() => {
+    if (!loaded) return;
+    try {
+      localStorage.setItem(key, JSON.stringify({ overrides, collapsed }));
+    } catch { /* quota exceeded */ }
+  }, [overrides, collapsed, loaded, key]);
+
+  function toggleOverride(id: string, currentAuto: EligibilityStatus) {
+    setOverrides((prev) => {
+      const current = prev[id] ?? null;
+      const next = nextOverride(current);
+      // If cycling back to null (auto), remove the key
+      if (next === null) {
+        const { [id]: _, ...rest } = prev;
+        return rest;
+      }
+      // Don't store if it's the same as auto (redundant)
+      if (next === currentAuto) {
+        const { [id]: _, ...rest } = prev;
+        return rest;
+      }
+      return { ...prev, [id]: next };
+    });
+  }
+
+  if (requirements.length === 0) {
+    return (
+      <div className="bg-gray-800/50 rounded-lg p-4">
+        <p className="text-gray-500 text-xs font-medium uppercase tracking-wide mb-2">Check Eligibility</p>
+        <p className="text-gray-400 text-sm">No structured eligibility conditions found — review the grant source directly.</p>
+      </div>
+    );
+  }
+
+  const resolved = requirements.map((r) => overrides[r.id] ?? r.autoStatus);
+  const passCount = resolved.filter((s) => s === "pass").length;
+  const failCount = resolved.filter((s) => s === "fail").length;
+  const unknownCount = resolved.filter((s) => s === "unknown").length;
+  const total = requirements.length;
+
+  const verdict =
+    failCount > 0 ? "Needs Review" :
+    unknownCount > 0 ? "Partially Eligible" :
+    "Likely Eligible";
+
+  const verdictColor =
+    verdict === "Likely Eligible" ? "bg-green-900/40 text-green-300" :
+    verdict === "Partially Eligible" ? "bg-yellow-900/40 text-yellow-300" :
+    "bg-red-900/40 text-red-300";
+
+  return (
+    <div className="bg-gray-800/50 rounded-lg p-4 space-y-3">
+      {/* Header */}
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="w-full flex items-center justify-between text-left gap-2"
+        aria-expanded={!collapsed}
+      >
+        <span className="text-gray-500 text-xs font-medium uppercase tracking-wide">Check Eligibility</span>
+        <div className="flex items-center gap-2">
+          <span className={`badge text-xs px-2 py-0.5 ${verdictColor}`}>{verdict}</span>
+          <svg
+            className={`w-4 h-4 text-gray-500 transition-transform ${collapsed ? "" : "rotate-180"}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </button>
+
+      {!collapsed && (
+        <>
+          {/* Summary */}
+          <p className="text-gray-400 text-xs">
+            <span className="text-green-400 font-medium">{passCount}/{total}</span> auto-checked
+            {unknownCount > 0 && <> · <span className="text-gray-300">{unknownCount} need{unknownCount === 1 ? "s" : ""} review</span></>}
+          </p>
+
+          {/* Requirement rows */}
+          <ul className="space-y-2">
+            {requirements.map((req) => {
+              const resolved = overrides[req.id] ?? req.autoStatus;
+              const isOverridden = overrides[req.id] != null;
+              return (
+                <li key={req.id} className="flex items-start gap-2">
+                  <span
+                    className={`mt-0.5 w-4 shrink-0 font-bold text-sm ${STATUS_COLOR[resolved]}`}
+                    aria-hidden="true"
+                  >
+                    {STATUS_ICON[resolved]}
+                  </span>
+                  <span className={`flex-1 text-sm leading-snug ${resolved === "fail" ? "text-red-200" : resolved === "pass" ? "text-gray-200" : "text-gray-400"}`}>
+                    {req.text}
+                  </span>
+                  <button
+                    onClick={() => toggleOverride(req.id, req.autoStatus)}
+                    title={isOverridden ? "Override active — click to cycle" : "Click to override"}
+                    className={`shrink-0 text-xs px-1.5 py-0.5 rounded transition-colors ${STATUS_BADGE[resolved]} ${isOverridden ? "ring-1 ring-white/20" : ""}`}
+                  >
+                    {STATUS_LABEL[resolved]}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <p className="text-gray-600 text-xs pt-1">Click a status badge to override auto-detection.</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/GrantDrawer.tsx
+++ b/ui/src/components/GrantDrawer.tsx
@@ -3,6 +3,7 @@ import type { Grant } from "../types";
 import type { UserProfile } from "../api";
 import { updateNotes } from "../api";
 import { FOCUS_AREA_KEYWORDS, ORG_TYPE_KEYWORDS, STAGE_KEYWORDS } from "../rankingKeywords";
+import EligibilitySimulator from "./EligibilitySimulator";
 
 interface Props {
   grant: Grant | null;
@@ -13,6 +14,7 @@ interface Props {
   onToggleWatchlist: (name: string) => void;
   onToggleCandidate: (name: string) => void;
   profile?: UserProfile | null;
+  username?: string;
 }
 
 const COLUMNS: (keyof Grant)[] = [
@@ -186,7 +188,7 @@ function ScoreBadge({ value }: { value: string | number }) {
   );
 }
 
-export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist, candidates, onToggleWatchlist, onToggleCandidate, profile }: Props) {
+export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist, candidates, onToggleWatchlist, onToggleCandidate, profile, username }: Props) {
   const [notes, setNotes] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
@@ -345,6 +347,15 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
                   </div>
                 );
               })()}
+
+              {/* Eligibility Simulator */}
+              {profile && (
+                <EligibilitySimulator
+                  grant={grant}
+                  profile={profile}
+                  username={username ?? "guest"}
+                />
+              )}
 
               {/* Fields grid */}
               <div className="grid grid-cols-2 gap-3">

--- a/ui/src/components/Login.tsx
+++ b/ui/src/components/Login.tsx
@@ -3,11 +3,12 @@ import { login } from "../api";
 
 interface Props {
   onSuccess: () => void;
+  onDemoSuccess: () => void;
   onSignUp: () => void;
   onForgotPassword: () => void;
 }
 
-export default function Login({ onSuccess, onSignUp, onForgotPassword }: Props) {
+export default function Login({ onSuccess, onDemoSuccess, onSignUp, onForgotPassword }: Props) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -32,7 +33,7 @@ export default function Login({ onSuccess, onSignUp, onForgotPassword }: Props) 
     setLoading(true);
     try {
       await login("demo", "demo");
-      onSuccess();
+      onDemoSuccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Demo login failed");
     } finally {
@@ -118,15 +119,11 @@ export default function Login({ onSuccess, onSignUp, onForgotPassword }: Props) 
             type="button"
             disabled={loading}
             onClick={handleTryDemo}
-            className="w-full flex items-center justify-center gap-2 rounded-lg border-2 border-green-500 bg-transparent hover:bg-green-500/10 text-green-400 text-sm font-medium py-2.5 transition-colors disabled:opacity-50"
+            className="w-full flex items-center justify-center gap-2 rounded-lg bg-green-600 hover:bg-green-500 text-white text-sm font-medium py-2.5 transition-colors disabled:opacity-50"
           >
             Try the demo
           </button>
         </form>
-
-        <p className="text-center text-gray-600 text-xs mt-3">
-          Demo account: <span className="font-mono text-gray-500">demo</span> / <span className="font-mono text-gray-500">demo</span>
-        </p>
 
         <p className="text-center text-gray-500 text-sm mt-4">
           Don't have an account?{" "}


### PR DESCRIPTION
## Summary

- **Remove demo credentials** — "Demo account: demo / demo" text no longer appears on the login page; the Try the demo button works silently
- **Style Try the demo button** — solid green background with white text, same visual weight as Sign in
- **Demo always lands on onboarding** — clicking Try the demo now routes to the "Tell us about yourself" screen with a blank profile, so the first thing a demo user sees is the mission statement input
- **Grant Eligibility Simulator** — new "Check Eligibility" section inside every grant drawer; parses eligibility conditions into a step-by-step checklist, auto-detects pass/fail/unknown from the user's saved org type and stage, supports manual override per row, and shows a verdict badge (Likely Eligible / Partially Eligible / Needs Review); state persists in localStorage per grant

## Test plan

- [ ] Click "Try the demo" on the login page — verify it goes straight to the onboarding screen with empty mission field
- [ ] Confirm no credentials text visible on the login page
- [ ] Confirm "Try the demo" button is solid green with white text
- [ ] Complete profile setup as Nonprofit/NGO at Pilot stage, open a grant with structured eligibility text — verify checklist rows appear with auto-detected statuses
- [ ] Override a row status and close/reopen the drawer — verify override persists
- [ ] Open a grant with blank eligibility field — verify empty-state message appears

https://claude.ai/code/session_01H6ej6jLf63p8S3fx2CWmk8

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6ej6jLf63p8S3fx2CWmk8)_