### PR TITLE
ci: use wrangler secret bulk to fix secrets never reaching deployed worker

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -44,20 +44,16 @@ jobs:
         # avoids that error but creates undeployed versions that the live worker
         # never sees — so secrets were silently never applied.
         run: |
-          # Build secrets JSON; conditionally include optional keys
-          python3 - <<'PYEOF'
-          import json, os, sys
-          secrets = {
-            "CF_ACCOUNT_ID": os.environ["CLOUDFLARE_ACCOUNT_ID"],
-            "CF_AI_TOKEN":   os.environ["CLOUDFLARE_API_TOKEN"],
-          }
-          key = os.environ.get("SIMPLER_GRANTS_API_KEY", "")
-          if key:
-            secrets["SIMPLER_GRANTS_API_KEY"] = key
-          else:
-            print("SIMPLER_GRANTS_API_KEY repo secret not set — skipping (live search stays disabled)", file=sys.stderr)
-          print(json.dumps(secrets))
-          PYEOF | npx wrangler secret bulk
+          SECRETS=$(jq -n \
+            --arg account_id "$CLOUDFLARE_ACCOUNT_ID" \
+            --arg ai_token "$CLOUDFLARE_API_TOKEN" \
+            '{"CF_ACCOUNT_ID": $account_id, "CF_AI_TOKEN": $ai_token}')
+          if [ -n "$SIMPLER_GRANTS_API_KEY" ]; then
+            SECRETS=$(echo "$SECRETS" | jq --arg key "$SIMPLER_GRANTS_API_KEY" '. + {"SIMPLER_GRANTS_API_KEY": $key}')
+          else
+            echo "SIMPLER_GRANTS_API_KEY repo secret not set — skipping (live search stays disabled)" >&2
+          fi
+          echo "$SECRETS" | npx wrangler secret bulk
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -37,18 +37,27 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Set worker secrets
-        # `versions secret put` updates secrets on the already-deployed version
-        # without creating a new deployment, avoiding the "latest version isn't
-        # currently deployed" error that plain `secret put` triggers when called
-        # multiple times in sequence.
+        # `wrangler secret bulk` sets all secrets in one atomic operation against
+        # the already-deployed version. Sequential `secret put` calls each create
+        # and immediately deploy a new version, causing the second call to fail
+        # with "latest version isn't currently deployed". `versions secret put`
+        # avoids that error but creates undeployed versions that the live worker
+        # never sees — so secrets were silently never applied.
         run: |
-          echo "$CLOUDFLARE_ACCOUNT_ID" | npx wrangler versions secret put CF_ACCOUNT_ID
-          echo "$CLOUDFLARE_API_TOKEN"  | npx wrangler versions secret put CF_AI_TOKEN
-          if [ -n "$SIMPLER_GRANTS_API_KEY" ]; then
-            echo "$SIMPLER_GRANTS_API_KEY" | npx wrangler versions secret put SIMPLER_GRANTS_API_KEY
-          else
-            echo "SIMPLER_GRANTS_API_KEY repo secret not set — skipping (live search stays disabled)"
-          fi
+          # Build secrets JSON; conditionally include optional keys
+          python3 - <<'PYEOF'
+          import json, os, sys
+          secrets = {
+            "CF_ACCOUNT_ID": os.environ["CLOUDFLARE_ACCOUNT_ID"],
+            "CF_AI_TOKEN":   os.environ["CLOUDFLARE_API_TOKEN"],
+          }
+          key = os.environ.get("SIMPLER_GRANTS_API_KEY", "")
+          if key:
+            secrets["SIMPLER_GRANTS_API_KEY"] = key
+          else:
+            print("SIMPLER_GRANTS_API_KEY repo secret not set — skipping (live search stays disabled)", file=sys.stderr)
+          print(json.dumps(secrets))
+          PYEOF | npx wrangler secret bulk
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
`wrangler versions secret put` was creating new undeployed versions for
each secret — the live worker never saw CF_ACCOUNT_ID or CF_AI_TOKEN, so
the AI REST API fallback silently failed every time.

Switch to `wrangler secret bulk` which sets all secrets in a single atomic
operation on the already-deployed version, matching how Cloudflare expects
secrets to be applied after a standard `wrangler deploy`.

https://claude.ai/code/session_017hHto1ENeqAMDojHoixFiB