### PR TITLE
Add pytest harness for program_scoring.py and agentic profile matcher worker

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -57,6 +57,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Create notification queue (idempotent)
+        # Must run before any worker that binds NOTIFY_QUEUE is deployed.
+        # wrangler exits 1 if the queue already exists; || echo treats that as success.
+        run: npx wrangler queues create grant-notify-queue || echo "Queue already exists — continuing"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy main worker
         working-directory: .
         run: npx wrangler deploy
@@ -90,13 +98,6 @@ jobs:
       - name: Deploy agents-starter
         working-directory: agents-starter-1
         run: npm ci && npx wrangler deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Create notification queue (idempotent)
-        # wrangler exits 1 if the queue already exists; treat that as success.
-        run: npx wrangler queues create grant-notify-queue || echo "Queue already exists — continuing"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -18,10 +18,20 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install dependencies
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Node dependencies
         run: npm ci
 
-      - name: Run worker tests
+      - name: Install Python dependencies
+        run: pip install pandas freezegun pytest
+
+      - name: Run scoring unit tests (pytest)
+        run: python -m pytest tests/test_program_scoring.py -v
+
+      - name: Run worker tests (vitest)
         run: npm run test:worker
 
   deploy:
@@ -83,3 +93,32 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Create notification queue (idempotent)
+        # wrangler exits 1 if the queue already exists; treat that as success.
+        run: npx wrangler queues create grant-notify-queue || echo "Queue already exists — continuing"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy profile matcher worker
+        run: npx wrangler deploy -c workers/profile_matcher_wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Set profile matcher secrets
+        # Mirrors the pattern used for the main worker above.
+        # Add RESEND_API_KEY as a GitHub Actions secret to enable email delivery.
+        # Without it this step is a no-op and the worker logs a warning at runtime.
+        run: |
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "RESEND_API_KEY repo secret not set — email notifications will be skipped at runtime" >&2
+            exit 0
+          fi
+          jq -n --arg key "$RESEND_API_KEY" '{"RESEND_API_KEY": $key}' \
+            | npx wrangler secret bulk -c workers/profile_matcher_wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "wrangler": "^4.98.0"
   },
   "scripts": {
-    "test": "pytest grant_summarizer",
+    "test": "pytest",
     "test:worker": "vitest run",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",

--- a/program_scoring.py
+++ b/program_scoring.py
@@ -83,9 +83,15 @@ def add_program_scores(df: pd.DataFrame) -> pd.DataFrame:
                 else:
                     cad_rec = max(0.0, 1 - min(days, 365) / 365)
 
-        r = pd.to_numeric(row["Relevance"], errors="coerce") or 0
-        f = pd.to_numeric(row["Fit"], errors="coerce") or 0
-        e = pd.to_numeric(row["Ease"], errors="coerce") or 0
+        # NaN is truthy in Python so `x or 0` does NOT coerce NaN to 0.
+        # Use explicit isna() check instead.
+        def _num(v: object) -> float:
+            x = pd.to_numeric(v, errors="coerce")
+            return 0.0 if pd.isna(x) else float(x)
+
+        r = _num(row["Relevance"])
+        f = _num(row["Fit"])
+        e = _num(row["Ease"])
         score = 0.3 * r + 0.3 * f + 0.2 * e + 0.1 * stack_alignment + 0.1 * cad_rec
 
         stack_align.append(round(stack_alignment, 3))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ dependencies = [
 [project.scripts]
 wrangle-grants = "wrangle_grants:main"
 search-grants = "search_grants:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ flask
 plotly
 pyyaml
 certifi
+pytest
+freezegun

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+import pathlib
+
+# Make the repo root importable so `program_scoring` and other root-level modules
+# can be imported in tests without installing the package.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))

--- a/tests/test_profile_matcher.test.js
+++ b/tests/test_profile_matcher.test.js
@@ -1,0 +1,549 @@
+/**
+ * Vitest tests for workers/profile_matcher_worker.js
+ *
+ * Environment:  @cloudflare/vitest-pool-workers (wrangler.test.toml)
+ * Test doubles: USER_PROFILES KV seeded in-process; D1 seeded via batch;
+ *               RESEND_API_KEY intentionally absent → email send is skipped.
+ */
+
+import { env, createExecutionContext, waitOnExecutionContext, reset } from "cloudflare:test";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import profileMatcher, { refineProfileFromSelections } from "../workers/profile_matcher_worker.js";
+import { buildEmailSummary } from "../workers/scoring_utils.js";
+
+// ---------------------------------------------------------------------------
+// Schema bootstrap (mirrors worker.test.js)
+// ---------------------------------------------------------------------------
+
+async function createSchema() {
+  const db = env.GRANT_MANAGER_DB;
+  await db.batch([
+    db.prepare(`CREATE TABLE IF NOT EXISTS programs (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      type                 TEXT,
+      name                 TEXT NOT NULL UNIQUE,
+      sponsor              TEXT,
+      source_url           TEXT,
+      region_eligibility   TEXT,
+      deadline             TEXT,
+      cadence              TEXT,
+      benefits             TEXT,
+      eligibility_conditions TEXT,
+      stage                TEXT,
+      non_dilutive         INTEGER,
+      stack_required       INTEGER,
+      relevance            REAL,
+      fit                  REAL,
+      ease                 REAL,
+      weighted_score       REAL,
+      notes                TEXT
+    )`),
+    db.prepare(`CREATE TABLE IF NOT EXISTS users (
+      username TEXT PRIMARY KEY,
+      password_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      email TEXT,
+      is_admin INTEGER DEFAULT 0
+    )`),
+  ]);
+}
+
+beforeEach(reset);
+beforeEach(createSchema);
+// Restore spies after each test so they don't accumulate across tests.
+afterEach(() => vi.restoreAllMocks());
+
+// ---------------------------------------------------------------------------
+// Grant seed data
+// ---------------------------------------------------------------------------
+
+async function seedGrants() {
+  const db = env.GRANT_MANAGER_DB;
+  await db.batch([
+    // Grant 1 — tech + nonprofit, rolling cadence, strong scores
+    db.prepare(`INSERT INTO programs (name, sponsor, type, benefits, cadence, deadline,
+                  stack_required, relevance, fit, ease)
+                VALUES ('TechFoundation Accelerator', 'TechFoundation', 'Accelerator',
+                  'technology innovation software nonprofit foundation', 'Rolling', NULL, 0, 3, 3, 3)`),
+    // Grant 2 — health focus
+    db.prepare(`INSERT INTO programs (name, sponsor, type, benefits, cadence, deadline,
+                  stack_required, relevance, fit, ease)
+                VALUES ('Health Research Grant', 'NIH', 'Grant',
+                  'health medicine medical clinical research', 'Annual', '2027-12-31', 0, 2, 2, 2)`),
+    // Grant 3 — stack_required=1, strong scores
+    db.prepare(`INSERT INTO programs (name, sponsor, type, benefits, cadence, deadline,
+                  stack_required, relevance, fit, ease)
+                VALUES ('Stack Partner Program', 'CloudCo', 'Accelerator',
+                  'technology software engineering', 'Rolling', NULL, 1, 2, 2, 3)`),
+    // Grant 4 — past deadline, should score 0 for CadenceRecency
+    db.prepare(`INSERT INTO programs (name, sponsor, type, benefits, cadence, deadline,
+                  stack_required, relevance, fit, ease)
+                VALUES ('Expired Grant', 'OldCo', 'Grant',
+                  'social welfare community', 'Annual', '2020-01-01', 0, 1, 1, 1)`),
+    // Grant 5 — rolling, low scores — may fall below threshold for some profiles
+    db.prepare(`INSERT INTO programs (name, sponsor, type, benefits, cadence, deadline,
+                  stack_required, relevance, fit, ease)
+                VALUES ('Low Score Rolling', 'Misc', 'Grant',
+                  'arts humanities culture', 'Rolling', NULL, 0, 0, 0, 0)`),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Profile seed helpers
+// ---------------------------------------------------------------------------
+
+// Alice: Technology focus, Nonprofit/NGO, high Relevance+Fit weight
+const ALICE_PROFILE = {
+  email: "alice@example.com",
+  focusAreas: ["Technology & Innovation"],
+  orgType: "Nonprofit/NGO",
+  stage: "",
+  weights: { Relevance: 0.35, Fit: 0.35, Ease: 0.2, StackAlignment: 0.05, CadenceRecency: 0.05 },
+};
+
+// Bob: Health focus — no grants in our seed match Health keyword well enough
+const BOB_PROFILE = {
+  email: "bob@example.com",
+  focusAreas: ["Health & Medicine"],
+  orgType: "Hospital/Health System",
+  stage: "",
+  weights: { Relevance: 0.3, Fit: 0.3, Ease: 0.2, StackAlignment: 0.1, CadenceRecency: 0.1 },
+};
+
+// Carol: Cares only about StackAlignment
+const CAROL_PROFILE = {
+  email: "carol@example.com",
+  focusAreas: [],
+  orgType: "",
+  stage: "",
+  weights: { Relevance: 0, Fit: 0, Ease: 0, StackAlignment: 1, CadenceRecency: 0 },
+};
+
+async function seedProfile(username, profile) {
+  await env.USER_PROFILES.put(`profile:${username}`, JSON.stringify(profile));
+}
+
+// ---------------------------------------------------------------------------
+// Helper: invoke the scheduled handler
+// ---------------------------------------------------------------------------
+
+async function runScheduled() {
+  const ctx = createExecutionContext();
+  await profileMatcher.scheduled({}, env, ctx);
+  await waitOnExecutionContext(ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: read all messages from the queue (not natively available in tests,
+// so we spy on NOTIFY_QUEUE.send to capture calls).
+// ---------------------------------------------------------------------------
+
+function captureQueueSends() {
+  const sent = [];
+  // Do NOT call through to the original: WorkerQueue.send is defined on the
+  // prototype, so .bind() still resolves through `this.send`, which now points
+  // at the spy — causing infinite recursion.  We only need to capture payloads.
+  vi.spyOn(env.NOTIFY_QUEUE, "send").mockImplementation(async (body) => {
+    sent.push(body);
+  });
+  return sent;
+}
+
+// ---------------------------------------------------------------------------
+// scheduled() — matching logic
+// ---------------------------------------------------------------------------
+
+describe("scheduled: matching logic", () => {
+  beforeEach(seedGrants);
+
+  it("queues a notification when a grant scores above the threshold for Alice", async () => {
+    await seedProfile("alice", ALICE_PROFILE);
+    const sent = captureQueueSends();
+
+    await runScheduled();
+
+    expect(sent.length).toBeGreaterThanOrEqual(1);
+    const msg = sent.find(m => m.username === "alice");
+    expect(msg).toBeDefined();
+    expect(msg.email).toBe("alice@example.com");
+    expect(Array.isArray(msg.matches)).toBe(true);
+    expect(msg.matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not queue grants below the threshold", async () => {
+    // Carol's StackAlignment-only weights: only stack_required=1 grants score high.
+    // 'Low Score Rolling' has relevance/fit/ease=0 and stack_required=0 → score = 0
+    await seedProfile("carol", CAROL_PROFILE);
+    const sent = captureQueueSends();
+
+    await runScheduled();
+
+    const carolMsg = sent.find(m => m.username === "carol");
+    if (carolMsg) {
+      const grantNames = carolMsg.matches.map(m => m.grant.name);
+      expect(grantNames).not.toContain("Low Score Rolling");
+    }
+  });
+
+  it("applies custom weights from the profile", async () => {
+    // Carol weights StackAlignment=1, everything else 0.
+    // Only 'Stack Partner Program' (stack_required=1) should appear.
+    await seedProfile("carol", CAROL_PROFILE);
+    const sent = captureQueueSends();
+
+    await runScheduled();
+
+    const carolMsg = sent.find(m => m.username === "carol");
+    expect(carolMsg).toBeDefined();
+    const grantNames = carolMsg.matches.map(m => m.grant.name);
+    expect(grantNames).toContain("Stack Partner Program");
+  });
+
+  it("matches are sorted by score descending within a queued message", async () => {
+    await seedProfile("alice", ALICE_PROFILE);
+    const sent = captureQueueSends();
+
+    await runScheduled();
+
+    const msg = sent.find(m => m.username === "alice");
+    if (msg && msg.matches.length > 1) {
+      for (let i = 1; i < msg.matches.length; i++) {
+        expect(msg.matches[i - 1].score).toBeGreaterThanOrEqual(msg.matches[i].score);
+      }
+    }
+  });
+
+  it("skips users without an email address", async () => {
+    const noEmailProfile = { ...ALICE_PROFILE, email: undefined };
+    await env.USER_PROFILES.put("profile:noemail", JSON.stringify(noEmailProfile));
+    const sent = captureQueueSends();
+
+    await runScheduled();
+
+    const msg = sent.find(m => m.username === "noemail");
+    expect(msg).toBeUndefined();
+  });
+
+  it("deduplicates: does not re-queue grants already marked notified", async () => {
+    await seedProfile("alice", ALICE_PROFILE);
+
+    // Pre-mark all 5 grants as already notified for alice.
+    for (let id = 1; id <= 5; id++) {
+      await env.USER_PROFILES.put(`notified:alice:${id}`, "1");
+    }
+
+    const sent = captureQueueSends();
+    await runScheduled();
+
+    const msg = sent.find(m => m.username === "alice");
+    expect(msg).toBeUndefined();
+  });
+
+  it("processes multiple users independently in the same run", async () => {
+    await seedProfile("alice", ALICE_PROFILE);
+    await seedProfile("carol", CAROL_PROFILE);
+    const sent = captureQueueSends();
+
+    await runScheduled();
+
+    const aliceMsg = sent.find(m => m.username === "alice");
+    const carolMsg = sent.find(m => m.username === "carol");
+    expect(aliceMsg).toBeDefined();
+    expect(carolMsg).toBeDefined();
+    expect(aliceMsg.matches).not.toBe(carolMsg.matches);
+  });
+
+  it("runs without error when there are no profiles", async () => {
+    await expect(runScheduled()).resolves.not.toThrow();
+  });
+
+  it("runs without error when the programs table is empty", async () => {
+    await seedProfile("alice", ALICE_PROFILE);
+    await expect(runScheduled()).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scheduled() — notified KV is written after queuing
+// ---------------------------------------------------------------------------
+
+describe("scheduled: deduplication state", () => {
+  beforeEach(seedGrants);
+
+  it("sets notified KV keys for each queued grant", async () => {
+    await seedProfile("alice", ALICE_PROFILE);
+    const sent = captureQueueSends();
+
+    await runScheduled();
+
+    const msg = sent.find(m => m.username === "alice");
+    if (!msg) return;  // no matches above threshold — nothing to check
+    for (const { grant } of msg.matches) {
+      const key = `notified:alice:${grant.id}`;
+      const val = await env.USER_PROFILES.get(key);
+      expect(val).toBe("1");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refineProfileFromSelections (pure unit tests — no env needed)
+// ---------------------------------------------------------------------------
+
+describe("refineProfileFromSelections", () => {
+  it("returns the original profile unchanged when there are no selections", () => {
+    const profile = { ...CAROL_PROFILE };
+    const result = refineProfileFromSelections(profile, []);
+    expect(result.weights).toEqual(profile.weights);
+  });
+
+  it("boosts StackAlignment when >50% of selections are stack-required", () => {
+    const profile = {
+      weights: { Relevance: 0.3, Fit: 0.3, Ease: 0.2, StackAlignment: 0.1, CadenceRecency: 0.1 },
+    };
+    const selections = [
+      { id: 1, stack_required: 1, cadence: "Annual", sponsor: "A" },
+      { id: 2, stack_required: 1, cadence: "Annual", sponsor: "B" },
+      { id: 3, stack_required: 0, cadence: "Annual", sponsor: "C" },
+    ];
+    const refined = refineProfileFromSelections(profile, selections);
+    expect(refined.weights.StackAlignment).toBeGreaterThan(profile.weights.StackAlignment);
+  });
+
+  it("boosts CadenceRecency when >50% of selections are rolling", () => {
+    const profile = {
+      weights: { Relevance: 0.3, Fit: 0.3, Ease: 0.2, StackAlignment: 0.1, CadenceRecency: 0.1 },
+    };
+    const selections = [
+      { id: 1, stack_required: 0, cadence: "Rolling", sponsor: "A" },
+      { id: 2, stack_required: 0, cadence: "Rolling", sponsor: "B" },
+      { id: 3, stack_required: 0, cadence: "Annual", sponsor: "C" },
+    ];
+    const refined = refineProfileFromSelections(profile, selections);
+    expect(refined.weights.CadenceRecency).toBeGreaterThan(profile.weights.CadenceRecency);
+  });
+
+  it("does not boost when ≤50% of selections match a dimension", () => {
+    const profile = {
+      weights: { Relevance: 0.3, Fit: 0.3, Ease: 0.2, StackAlignment: 0.1, CadenceRecency: 0.1 },
+    };
+    const selections = [
+      { id: 1, stack_required: 1, cadence: "Annual", sponsor: "A" },
+      { id: 2, stack_required: 0, cadence: "Annual", sponsor: "B" },
+    ];
+    const refined = refineProfileFromSelections(profile, selections);
+    // 1/2 = exactly 50%, not > 50%, so no boost
+    expect(refined.weights.StackAlignment).toEqual(profile.weights.StackAlignment);
+  });
+
+  it("caps StackAlignment boost at 0.25", () => {
+    const profile = {
+      weights: { Relevance: 0.1, Fit: 0.1, Ease: 0.1, StackAlignment: 0.25, CadenceRecency: 0.1 },
+    };
+    const selections = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1, stack_required: 1, cadence: "Annual", sponsor: "A",
+    }));
+    // Run multiple times to attempt to push past cap.
+    let p = profile;
+    for (let i = 0; i < 5; i++) p = refineProfileFromSelections(p, selections);
+
+    const rawWeight = p.weights.StackAlignment * Object.values(p.weights).reduce((a, b) => a + b, 0);
+    // After renormalization, StackAlignment / sum should not exceed 0.25 / sum before renorm.
+    // The cap is applied before renormalization.
+    expect(rawWeight).toBeLessThanOrEqual(0.26);  // small tolerance for renorm arithmetic
+  });
+
+  it("renormalizes weights so they sum to ~1.0", () => {
+    const profile = {
+      weights: { Relevance: 0.3, Fit: 0.3, Ease: 0.2, StackAlignment: 0.1, CadenceRecency: 0.1 },
+    };
+    const selections = [
+      { id: 1, stack_required: 1, cadence: "Rolling", sponsor: "A" },
+      { id: 2, stack_required: 1, cadence: "Rolling", sponsor: "B" },
+    ];
+    const refined = refineProfileFromSelections(profile, selections);
+    const sum = Object.values(refined.weights).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1.0, 5);
+  });
+
+  it("builds a sponsorAffinity map from selections", () => {
+    const profile = { weights: { Relevance: 0.3, Fit: 0.3, Ease: 0.2, StackAlignment: 0.1, CadenceRecency: 0.1 } };
+    const selections = [
+      { id: 1, stack_required: 0, cadence: "Annual", sponsor: "Sponsor A" },
+      { id: 2, stack_required: 0, cadence: "Annual", sponsor: "Sponsor A" },
+      { id: 3, stack_required: 0, cadence: "Annual", sponsor: "Sponsor B" },
+    ];
+    const refined = refineProfileFromSelections(profile, selections);
+    expect(refined.sponsorAffinity).toEqual({ "Sponsor A": 2, "Sponsor B": 1 });
+  });
+
+  it("handles null/undefined selections gracefully", () => {
+    const profile = { weights: { ...DEFAULT_WEIGHTS_TEST } };
+    expect(() => refineProfileFromSelections(profile, null)).not.toThrow();
+    expect(() => refineProfileFromSelections(profile, undefined)).not.toThrow();
+  });
+});
+
+const DEFAULT_WEIGHTS_TEST = { Relevance: 0.3, Fit: 0.3, Ease: 0.2, StackAlignment: 0.1, CadenceRecency: 0.1 };
+
+// ---------------------------------------------------------------------------
+// queue handler — notification consumer
+// ---------------------------------------------------------------------------
+
+describe("queue: notification consumer", () => {
+  it("acks all messages after processing", async () => {
+    const ackedIds = [];
+    const batch = {
+      messages: [
+        {
+          id: "msg-1",
+          body: {
+            username: "alice",
+            email: "alice@example.com",
+            matches: [{ grant: { id: 1, name: "Test Grant", sponsor: "TestCo", deadline: null }, score: 8.5 }],
+          },
+          ack: () => ackedIds.push("msg-1"),
+          retry: () => {},
+        },
+        {
+          id: "msg-2",
+          body: { username: "missing-email", email: null, matches: [] },
+          ack: () => ackedIds.push("msg-2"),
+          retry: () => {},
+        },
+      ],
+    };
+
+    const ctx = createExecutionContext();
+    await profileMatcher.queue(batch, env);
+    await waitOnExecutionContext(ctx);
+
+    // Both messages must be acked (no RESEND_API_KEY in test env → graceful skip for msg-1)
+    expect(ackedIds).toContain("msg-1");
+    expect(ackedIds).toContain("msg-2");
+  });
+
+  it("does not throw when email is missing from the profile", async () => {
+    const batch = {
+      messages: [
+        {
+          id: "msg-1",
+          body: { username: "nobody", email: null, matches: [{ grant: { id: 1, name: "G", sponsor: "S" }, score: 7 }] },
+          ack: vi.fn(),
+          retry: vi.fn(),
+        },
+      ],
+    };
+    await expect(profileMatcher.queue(batch, env)).resolves.not.toThrow();
+    expect(batch.messages[0].ack).toHaveBeenCalled();
+  });
+
+  it("does not throw when matches array is empty", async () => {
+    const batch = {
+      messages: [
+        {
+          id: "msg-1",
+          body: { username: "alice", email: "alice@example.com", matches: [] },
+          ack: vi.fn(),
+          retry: vi.fn(),
+        },
+      ],
+    };
+    await expect(profileMatcher.queue(batch, env)).resolves.not.toThrow();
+    expect(batch.messages[0].ack).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildEmailSummary (pure function — no bindings needed)
+// ---------------------------------------------------------------------------
+
+describe("buildEmailSummary", () => {
+  const matches = [
+    { grant: { name: "TechFoundation Accelerator", sponsor: "TechFoundation", deadline: null }, score: 9.1 },
+    { grant: { name: "Stack Partner Program", sponsor: "CloudCo", deadline: "2026-09-30" }, score: 7.4 },
+  ];
+
+  it("subject contains the match count", () => {
+    const { subject } = buildEmailSummary("alice", matches);
+    expect(subject).toContain("2");
+  });
+
+  it("singular subject when there is exactly one match", () => {
+    const { subject } = buildEmailSummary("alice", [matches[0]]);
+    expect(subject).toMatch(/1 new grant match\b/);
+    expect(subject).not.toMatch(/matches/);
+  });
+
+  it("body HTML contains the username", () => {
+    const { html } = buildEmailSummary("alice", matches);
+    expect(html).toContain("alice");
+  });
+
+  it("body HTML contains all grant names", () => {
+    const { html } = buildEmailSummary("alice", matches);
+    expect(html).toContain("TechFoundation Accelerator");
+    expect(html).toContain("Stack Partner Program");
+  });
+
+  it("body HTML contains sponsor names", () => {
+    const { html } = buildEmailSummary("alice", matches);
+    expect(html).toContain("TechFoundation");
+    expect(html).toContain("CloudCo");
+  });
+
+  it("body HTML contains formatted scores", () => {
+    const { html } = buildEmailSummary("alice", matches);
+    expect(html).toContain("9.1");
+    expect(html).toContain("7.4");
+  });
+
+  it("body HTML contains deadline information when present", () => {
+    const { html } = buildEmailSummary("alice", matches);
+    expect(html).toContain("2026-09-30");
+  });
+
+  it("escapes HTML characters in grant names to prevent XSS", () => {
+    const xssMatches = [
+      { grant: { name: '<script>alert("xss")</script>', sponsor: "Bad Actor", deadline: null }, score: 8 },
+    ];
+    const { html } = buildEmailSummary("alice", xssMatches);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("returns valid HTML structure with html/body tags", () => {
+    const { html } = buildEmailSummary("alice", matches);
+    expect(html).toContain("<html");
+    expect(html).toContain("<body");
+    expect(html).toContain("</body>");
+    expect(html).toContain("</html>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// worker.js integration — /api/profile/select-grant
+// ---------------------------------------------------------------------------
+
+describe("POST /api/profile/select-grant", () => {
+  it("requires authentication", async () => {
+    const res = await fetch(new Request("http://localhost/api/profile/select-grant", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ grantId: 1 }),
+    }));
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Import the main worker for the select-grant auth test above
+// ---------------------------------------------------------------------------
+import worker from "../worker.js";
+
+async function fetch(request) {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(request, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}

--- a/tests/test_program_scoring.py
+++ b/tests/test_program_scoring.py
@@ -1,0 +1,491 @@
+"""
+pytest suite for program_scoring.add_program_scores().
+
+Tests are frozen at 2026-06-14 so deadline-relative assertions stay stable.
+The weighted score formula is:
+  0.3*Relevance + 0.3*Fit + 0.2*Ease + 0.1*StackAlignment + 0.1*CadenceRecency
+
+Where:
+  StackAlignment  = 1.0 if "yes" in Stack Required? else 0.2
+  CadenceRecency  = 1.0 if rolling else max(0, 1 - min(days_until_deadline, 365) / 365)
+"""
+
+import pytest
+import pandas as pd
+from freezegun import freeze_time
+
+from program_scoring import add_program_scores, _normalize_columns, _validate_columns
+
+
+# ---------------------------------------------------------------------------
+# Shared sample data (frozen at 2026-06-14)
+# ---------------------------------------------------------------------------
+
+# 2026-06-14 + 30 days  = 2026-07-14   → CadenceRecency = 1 - 30/365 ≈ 0.918
+# 2026-06-14 + 400 days = 2027-07-19   → CadenceRecency = max(0, 1 - 365/365) = 0.0
+
+_SAMPLE_PROGRAMS = [
+    {   # Program 0 — rolling + stack yes → maximum on both computed dims
+        "name": "Rolling Stack Accelerator",
+        "Stack Required?": "yes",
+        "Deadline / Next Cohort": "Rolling",
+        "Cadence": "Rolling",
+        "Relevance": 3.0,
+        "Fit": 3.0,
+        "Ease": 3.0,
+    },
+    {   # Program 1 — near deadline (30 days) + stack no
+        "name": "Near Deadline Grant",
+        "Stack Required?": "no",
+        "Deadline / Next Cohort": "2026-07-14",
+        "Cadence": "Annual",
+        "Relevance": 2.0,
+        "Fit": 2.0,
+        "Ease": 2.0,
+    },
+    {   # Program 2 — far future (400 days → clamped → CR=0) + stack yes
+        "name": "Far Future Grant",
+        "Stack Required?": "yes",
+        "Deadline / Next Cohort": "2027-07-19",
+        "Cadence": "Annual",
+        "Relevance": 1.0,
+        "Fit": 1.0,
+        "Ease": 1.0,
+    },
+    {   # Program 3 — past deadline + no stack → both computed fields = 0
+        "name": "Past Deadline Grant",
+        "Stack Required?": "no",
+        "Deadline / Next Cohort": "2025-01-01",
+        "Cadence": "Annual",
+        "Relevance": 2.0,
+        "Fit": 2.0,
+        "Ease": 2.0,
+    },
+    {   # Program 4 — missing numeric fields + rolling → numeric coercion
+        "name": "Bare Minimum Grant",
+        "Stack Required?": "unknown",
+        "Deadline / Next Cohort": "Rolling",
+        "Cadence": "",
+        "Relevance": None,
+        "Fit": None,
+        "Ease": None,
+    },
+]
+
+
+@pytest.fixture
+def sample_df():
+    """All 5 sample programs as a DataFrame."""
+    return pd.DataFrame(_SAMPLE_PROGRAMS)
+
+
+def _one_row(**kwargs) -> pd.DataFrame:
+    """Build a single-row DataFrame with required columns and kwargs overrides."""
+    base = {
+        "Stack Required?": "no",
+        "Deadline / Next Cohort": "Rolling",
+        "Cadence": "Rolling",
+        "Relevance": 1.0,
+        "Fit": 1.0,
+        "Ease": 1.0,
+    }
+    base.update(kwargs)
+    return pd.DataFrame([base])
+
+
+# ---------------------------------------------------------------------------
+# Formula correctness
+# ---------------------------------------------------------------------------
+
+
+@freeze_time("2026-06-14")
+def test_weighted_score_formula_rolling_stack_yes(sample_df):
+    """Program 0: max inputs → 0.3*3 + 0.3*3 + 0.2*3 + 0.1*1.0 + 0.1*1.0 = 2.6."""
+    result = add_program_scores(sample_df)
+    row = result[result["name"] == "Rolling Stack Accelerator"].iloc[0]
+    assert row["StackAlignment"] == pytest.approx(1.0)
+    assert row["CadenceRecency"] == pytest.approx(1.0)
+    assert row["Weighted Score"] == pytest.approx(2.6, abs=1e-3)
+
+
+@freeze_time("2026-06-14")
+def test_weighted_score_formula_past_deadline_no_stack(sample_df):
+    """Program 3: CR=0, SA=0.2, R/F/E=2.0 → 0.3*2 + 0.3*2 + 0.2*2 + 0.1*0.2 + 0 = 1.62."""
+    result = add_program_scores(sample_df)
+    row = result[result["name"] == "Past Deadline Grant"].iloc[0]
+    assert row["StackAlignment"] == pytest.approx(0.2)
+    assert row["CadenceRecency"] == pytest.approx(0.0)
+    assert row["Weighted Score"] == pytest.approx(1.62, abs=1e-3)
+
+
+@freeze_time("2026-06-14")
+def test_weighted_score_formula_near_deadline_no_stack(sample_df):
+    """Program 1: 30 days, no stack → formula using CR≈0.918, SA=0.2."""
+    result = add_program_scores(sample_df)
+    row = result[result["name"] == "Near Deadline Grant"].iloc[0]
+    expected = 0.3 * 2.0 + 0.3 * 2.0 + 0.2 * 2.0 + 0.1 * 0.2 + 0.1 * row["CadenceRecency"]
+    assert row["Weighted Score"] == pytest.approx(round(expected, 3), abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# CadenceRecency edge cases
+# ---------------------------------------------------------------------------
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_rolling_keyword_in_deadline():
+    """'Rolling' in Deadline column → CadenceRecency = 1.0."""
+    df = _one_row(**{"Deadline / Next Cohort": "Rolling", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(1.0)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_rolling_keyword_in_cadence():
+    """'Rolling' in Cadence column (even with a date deadline) → CadenceRecency = 1.0."""
+    df = _one_row(**{"Deadline / Next Cohort": "2026-09-01", "Cadence": "Rolling"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(1.0)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_near_deadline_30_days():
+    """30 days until deadline → 1 - 30/365 ≈ 0.918."""
+    df = _one_row(**{"Deadline / Next Cohort": "2026-07-14", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    expected = round(1 - 30 / 365, 3)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(expected, abs=1e-3)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_near_deadline_182_days():
+    """182 days until deadline → 1 - 182/365 ≈ 0.501."""
+    df = _one_row(**{"Deadline / Next Cohort": "2026-12-13", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    expected = round(1 - 182 / 365, 3)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(expected, abs=1e-3)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_far_future_clamped_to_zero():
+    """400 days away → min(400,365)/365 = 1.0 → CadenceRecency = 0.0."""
+    df = _one_row(**{"Deadline / Next Cohort": "2027-07-19", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(0.0)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_exactly_365_days():
+    """Exactly 365 days away → 1 - 365/365 = 0.0."""
+    df = _one_row(**{"Deadline / Next Cohort": "2027-06-14", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(0.0)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_past_deadline():
+    """Past deadline → CadenceRecency = 0.0."""
+    df = _one_row(**{"Deadline / Next Cohort": "2025-01-01", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(0.0)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_unparseable_deadline():
+    """Unparseable deadline string ('N/A') → CadenceRecency = 0.0."""
+    df = _one_row(**{"Deadline / Next Cohort": "N/A", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(0.0)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_empty_deadline():
+    """Empty string deadline → CadenceRecency = 0.0."""
+    df = _one_row(**{"Deadline / Next Cohort": "", "Cadence": "Annual"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(0.0)
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_nan_deadline():
+    """NaN deadline (float) → CadenceRecency = 0.0."""
+    import math
+    df = _one_row(**{"Deadline / Next Cohort": float("nan"), "Cadence": "Annual"})
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# StackAlignment edge cases
+# ---------------------------------------------------------------------------
+
+
+@freeze_time("2026-06-14")
+def test_stack_alignment_yes_exact():
+    """'yes' → StackAlignment = 1.0."""
+    df = _one_row(**{"Stack Required?": "yes"})
+    result = add_program_scores(df)
+    assert result["StackAlignment"].iloc[0] == pytest.approx(1.0)
+
+
+@freeze_time("2026-06-14")
+@pytest.mark.parametrize("value", ["Yes", "YES", "YES please", "yes "])
+def test_stack_alignment_yes_variants(value):
+    """Any string containing 'yes' (case-insensitive) → StackAlignment = 1.0."""
+    df = _one_row(**{"Stack Required?": value})
+    result = add_program_scores(df)
+    assert result["StackAlignment"].iloc[0] == pytest.approx(1.0), f"Failed for: {value!r}"
+
+
+@freeze_time("2026-06-14")
+def test_stack_alignment_no():
+    """'no' → StackAlignment = 0.2."""
+    df = _one_row(**{"Stack Required?": "no"})
+    result = add_program_scores(df)
+    assert result["StackAlignment"].iloc[0] == pytest.approx(0.2)
+
+
+@freeze_time("2026-06-14")
+@pytest.mark.parametrize("value", ["unknown", "n/a", "TBD", "", "maybe", "1"])
+def test_stack_alignment_non_yes_defaults_to_0_2(value):
+    """Any value not containing 'yes' → StackAlignment = 0.2."""
+    df = _one_row(**{"Stack Required?": value})
+    result = add_program_scores(df)
+    assert result["StackAlignment"].iloc[0] == pytest.approx(0.2), f"Failed for: {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# Column alias normalization
+# ---------------------------------------------------------------------------
+
+
+@freeze_time("2026-06-14")
+def test_alias_stack_required_no_space():
+    """Column 'StackRequired' is accepted as alias for 'Stack Required?'."""
+    df = pd.DataFrame([{
+        "StackRequired": "yes",
+        "Deadline / Next Cohort": "Rolling",
+        "Cadence": "Rolling",
+        "Relevance": 1.0, "Fit": 1.0, "Ease": 1.0,
+    }])
+    result = add_program_scores(df)
+    assert result["StackAlignment"].iloc[0] == pytest.approx(1.0)
+
+
+@freeze_time("2026-06-14")
+def test_alias_stack_required_without_question_mark():
+    """Column 'Stack Required' (no '?') is accepted as alias."""
+    df = pd.DataFrame([{
+        "Stack Required": "yes",
+        "Deadline / Next Cohort": "Rolling",
+        "Cadence": "Rolling",
+        "Relevance": 1.0, "Fit": 1.0, "Ease": 1.0,
+    }])
+    result = add_program_scores(df)
+    assert result["StackAlignment"].iloc[0] == pytest.approx(1.0)
+
+
+@freeze_time("2026-06-14")
+def test_alias_deadline_iso():
+    """Column 'DeadlineISO' is accepted as alias for 'Deadline / Next Cohort'."""
+    df = pd.DataFrame([{
+        "Stack Required?": "no",
+        "DeadlineISO": "Rolling",
+        "Cadence": "Rolling",
+        "Relevance": 1.0, "Fit": 1.0, "Ease": 1.0,
+    }])
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(1.0)
+
+
+@freeze_time("2026-06-14")
+def test_alias_deadline_plain():
+    """Column 'Deadline' is accepted as alias for 'Deadline / Next Cohort'."""
+    df = pd.DataFrame([{
+        "Stack Required?": "no",
+        "Deadline": "Rolling",
+        "Cadence": "Rolling",
+        "Relevance": 1.0, "Fit": 1.0, "Ease": 1.0,
+    }])
+    result = add_program_scores(df)
+    assert result["CadenceRecency"].iloc[0] == pytest.approx(1.0)
+
+
+@freeze_time("2026-06-14")
+def test_alias_ease_of_use():
+    """Column 'Ease of Use' is accepted as alias for 'Ease'."""
+    df = pd.DataFrame([{
+        "Stack Required?": "no",
+        "Deadline / Next Cohort": "Rolling",
+        "Cadence": "Rolling",
+        "Relevance": 1.0, "Fit": 1.0, "Ease of Use": 2.0,
+    }])
+    result = add_program_scores(df)
+    expected_score = 0.3 * 1.0 + 0.3 * 1.0 + 0.2 * 2.0 + 0.1 * 0.2 + 0.1 * 1.0
+    assert result["Weighted Score"].iloc[0] == pytest.approx(round(expected_score, 3), abs=1e-3)
+
+
+@freeze_time("2026-06-14")
+def test_canonical_names_pass_through():
+    """When canonical column names are already present, no renaming occurs."""
+    df = _one_row(**{"Stack Required?": "yes"})
+    normalized = _normalize_columns(df.copy())
+    assert "Stack Required?" in normalized.columns
+    assert "Deadline / Next Cohort" in normalized.columns
+
+
+# ---------------------------------------------------------------------------
+# Validation — missing required columns
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_column_raises_value_error():
+    """A DataFrame missing 'Relevance' raises ValueError."""
+    df = pd.DataFrame([{
+        "Stack Required?": "no",
+        "Deadline / Next Cohort": "Rolling",
+        "Cadence": "Rolling",
+        "Fit": 1.0,
+        "Ease": 1.0,
+        # "Relevance" deliberately omitted
+    }])
+    with pytest.raises(ValueError, match="Relevance"):
+        add_program_scores(df)
+
+
+def test_missing_multiple_columns_lists_all_in_error():
+    """ValueError message lists every missing column, not just the first."""
+    df = pd.DataFrame([{"name": "stub"}])
+    with pytest.raises(ValueError) as exc_info:
+        add_program_scores(df)
+    msg = str(exc_info.value)
+    assert "Stack Required?" in msg or "Relevance" in msg  # at least one missing column named
+    assert "Found columns:" in msg
+
+
+def test_validate_columns_raises_for_empty_dataframe():
+    """An empty DataFrame (no columns) raises ValueError."""
+    df = pd.DataFrame()
+    with pytest.raises(ValueError):
+        _validate_columns(df)
+
+
+# ---------------------------------------------------------------------------
+# Missing / null numeric fields
+# ---------------------------------------------------------------------------
+
+
+@freeze_time("2026-06-14")
+def test_null_relevance_fit_ease_default_to_zero():
+    """None values for Relevance/Fit/Ease coerce to 0; score = 0.1*SA + 0.1*CR."""
+    df = _one_row(**{"Relevance": None, "Fit": None, "Ease": None,
+                     "Stack Required?": "yes", "Deadline / Next Cohort": "Rolling", "Cadence": "Rolling"})
+    result = add_program_scores(df)
+    # 0*0.3 + 0*0.3 + 0*0.2 + 1.0*0.1 + 1.0*0.1 = 0.2
+    assert result["Weighted Score"].iloc[0] == pytest.approx(0.2, abs=1e-3)
+
+
+@freeze_time("2026-06-14")
+@pytest.mark.parametrize("bad_value", ["TBD", "N/A", "", "unknown"])
+def test_non_numeric_string_fields_default_to_zero(bad_value):
+    """Non-numeric strings in Relevance/Fit/Ease coerce to 0 without raising."""
+    df = _one_row(**{"Relevance": bad_value, "Fit": bad_value, "Ease": bad_value,
+                     "Stack Required?": "no", "Deadline / Next Cohort": "Rolling", "Cadence": "Rolling"})
+    result = add_program_scores(df)
+    # 0.1*0.2 + 0.1*1.0 = 0.12
+    assert result["Weighted Score"].iloc[0] == pytest.approx(0.12, abs=1e-3)
+
+
+@freeze_time("2026-06-14")
+def test_bare_minimum_grant_in_full_fixture(sample_df):
+    """Program 4 (Bare Minimum) scores without raising even with all-None numerics."""
+    result = add_program_scores(sample_df)
+    row = result[result["name"] == "Bare Minimum Grant"].iloc[0]
+    # rolling + stack unknown(0.2) → 0 + 0 + 0 + 0.02 + 0.1 = 0.12
+    assert row["Weighted Score"] == pytest.approx(0.12, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Output shape
+# ---------------------------------------------------------------------------
+
+
+@freeze_time("2026-06-14")
+def test_output_contains_stack_alignment_column(sample_df):
+    result = add_program_scores(sample_df)
+    assert "StackAlignment" in result.columns
+
+
+@freeze_time("2026-06-14")
+def test_output_contains_cadence_recency_column(sample_df):
+    result = add_program_scores(sample_df)
+    assert "CadenceRecency" in result.columns
+
+
+@freeze_time("2026-06-14")
+def test_output_contains_weighted_score_column(sample_df):
+    result = add_program_scores(sample_df)
+    assert "Weighted Score" in result.columns
+
+
+@freeze_time("2026-06-14")
+def test_all_rows_scored(sample_df):
+    """Every row in the 5-program fixture receives a Weighted Score (no NaNs)."""
+    result = add_program_scores(sample_df)
+    assert len(result) == 5
+    assert result["Weighted Score"].notna().all()
+
+
+@freeze_time("2026-06-14")
+def test_original_columns_preserved(sample_df):
+    """add_program_scores does not drop any input columns."""
+    result = add_program_scores(sample_df)
+    for col in sample_df.columns:
+        assert col in result.columns
+
+
+@freeze_time("2026-06-14")
+def test_scores_are_rounded_to_3_decimal_places(sample_df):
+    """Weighted Score, StackAlignment, CadenceRecency are rounded to 3 decimals."""
+    result = add_program_scores(sample_df)
+    for _, row in result.iterrows():
+        for field in ("StackAlignment", "CadenceRecency", "Weighted Score"):
+            val = row[field]
+            assert round(val, 3) == val, f"{field}={val} has more than 3 decimal places"
+
+
+@freeze_time("2026-06-14")
+def test_weighted_scores_are_non_negative(sample_df):
+    result = add_program_scores(sample_df)
+    assert (result["Weighted Score"] >= 0).all()
+
+
+@freeze_time("2026-06-14")
+def test_stack_alignment_values_are_either_0_2_or_1_0(sample_df):
+    result = add_program_scores(sample_df)
+    valid = {0.2, 1.0}
+    for val in result["StackAlignment"]:
+        assert val in valid, f"Unexpected StackAlignment value: {val}"
+
+
+@freeze_time("2026-06-14")
+def test_cadence_recency_within_0_1_range(sample_df):
+    result = add_program_scores(sample_df)
+    assert (result["CadenceRecency"] >= 0).all()
+    assert (result["CadenceRecency"] <= 1).all()
+
+
+# ---------------------------------------------------------------------------
+# Single-row sanity: far-future grant
+# ---------------------------------------------------------------------------
+
+
+@freeze_time("2026-06-14")
+def test_far_future_grant_in_full_fixture(sample_df):
+    """Program 2: 400 days out, stack yes → CR=0.0, SA=1.0."""
+    result = add_program_scores(sample_df)
+    row = result[result["name"] == "Far Future Grant"].iloc[0]
+    assert row["CadenceRecency"] == pytest.approx(0.0)
+    assert row["StackAlignment"] == pytest.approx(1.0)
+    # score = 0.3*1 + 0.3*1 + 0.2*1 + 0.1*1.0 + 0.1*0.0 = 0.9
+    assert row["Weighted Score"] == pytest.approx(0.9, abs=1e-3)

--- a/worker.js
+++ b/worker.js
@@ -769,6 +769,38 @@ async function handleRequest(request, env, ctx) {
       }
     }
 
+    if (url.pathname === "/api/profile/select-grant") {
+      if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+      if (!(await validateCsrf(request, env, username))) {
+        return new Response("Forbidden", { status: 403 });
+      }
+      if (!env.USER_PROFILES) return new Response("KV not configured", { status: 503 });
+
+      const { grantId } = await request.json();
+      const id = Number(grantId);
+      if (!Number.isFinite(id) || id <= 0) {
+        return new Response(JSON.stringify({ error: "Invalid grantId" }), { status: 400 });
+      }
+
+      const key = `selections:${username}`;
+      const existing = await env.USER_PROFILES.get(key, "json").catch(() => null);
+      const selections = Array.isArray(existing) ? existing : [];
+
+      if (request.method === "POST") {
+        if (!selections.includes(id)) selections.push(id);
+        await env.USER_PROFILES.put(key, JSON.stringify(selections));
+        log("info", "grant_selected", { ...reqCtx, grantId: id });
+        return jsonResponse(JSON.stringify({ ok: true, selected: selections }));
+      }
+
+      if (request.method === "DELETE") {
+        const updated = selections.filter(s => s !== id);
+        await env.USER_PROFILES.put(key, JSON.stringify(updated));
+        log("info", "grant_deselected", { ...reqCtx, grantId: id });
+        return jsonResponse(JSON.stringify({ ok: true, selected: updated }));
+      }
+    }
+
     if (url.pathname === "/api/profile/analyze-mission" && request.method === "POST") {
       if (!loggedIn) return new Response("Unauthorized", { status: 401 });
       if (!(await validateCsrf(request, env, username))) return new Response("Forbidden", { status: 403 });

--- a/workers/profile_matcher_worker.js
+++ b/workers/profile_matcher_worker.js
@@ -1,0 +1,230 @@
+/**
+ * FoundationPlanner — Profile Matcher Worker
+ *
+ * Triggered:
+ *   scheduled  — cron (daily at 08:00 UTC).  Scores all D1 grants against every
+ *                user profile, queues notifications for high-scoring matches.
+ *   queue      — NOTIFY_QUEUE consumer.  Sends one summary email per message
+ *                via the Resend API.
+ *
+ * Required bindings (workers/profile_matcher_wrangler.toml):
+ *   USER_PROFILES  KV namespace  (shared with the main web worker)
+ *   GRANT_MANAGER_DB  D1 database  (shared)
+ *   NOTIFY_QUEUE   Queue producer + consumer
+ *
+ * Required secrets (set with wrangler secret put):
+ *   RESEND_API_KEY
+ *
+ * Optional env vars (set in [vars]):
+ *   SCORE_THRESHOLD  float, default 6.0
+ */
+
+import {
+  computeScore,
+  buildEmailSummary,
+  DEFAULT_WEIGHTS,
+} from "./scoring_utils.js";
+
+// KV key prefixes — must match the main worker.js conventions.
+const PROFILE_PREFIX    = "profile:";
+const SELECTIONS_PREFIX = "selections:";
+const NOTIFIED_PREFIX   = "notified:";
+
+// TTL for the "already notified" deduplication key (30 days).
+const NOTIFIED_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+// How many grants to process per user per run (guard against very large tables).
+const GRANT_BATCH_LIMIT = 200;
+
+// Maximum matches to include in a single notification.
+const MAX_MATCHES_PER_EMAIL = 10;
+
+// ---------------------------------------------------------------------------
+// Scheduled handler — daily profile matching
+// ---------------------------------------------------------------------------
+
+async function runScheduled(env) {
+  const threshold = parseFloat(env.SCORE_THRESHOLD ?? "6.0");
+
+  // List all profile keys.  USER_PROFILES stores profiles under "profile:{username}".
+  const profileList = await env.USER_PROFILES.list({ prefix: PROFILE_PREFIX });
+  if (!profileList.keys.length) return;
+
+  // Fetch all grants once and share across profiles (avoids N×M D1 queries).
+  const grants = await fetchAllGrants(env.GRANT_MANAGER_DB);
+  if (!grants.length) return;
+
+  for (const { name: kvKey } of profileList.keys) {
+    const username = kvKey.slice(PROFILE_PREFIX.length);
+    try {
+      await processUser(env, username, grants, threshold);
+    } catch (err) {
+      // Isolate per-user failures so one bad profile can't abort the whole run.
+      console.error(`profile_matcher: error processing user ${username}`, err);
+    }
+  }
+}
+
+async function processUser(env, username, grants, threshold) {
+  const rawProfile = await env.USER_PROFILES.get(PROFILE_PREFIX + username, "json");
+  if (!rawProfile) return;
+
+  // Skip users with no email — we have nowhere to send the notification.
+  const email = rawProfile.email;
+  if (!email) return;
+
+  // Fetch selection history and refine profile weights.
+  const selectionIds = await loadSelectionIds(env, username);
+  const selectedGrants = grants.filter(g => selectionIds.has(g.id));
+  const profile = refineProfileFromSelections(rawProfile, selectedGrants);
+
+  const matches = [];
+  for (const grant of grants) {
+    const score = computeScore(grant, profile.weights ?? DEFAULT_WEIGHTS, profile);
+    if (score < threshold) continue;
+
+    // Deduplication: skip grants we already notified this user about.
+    const dedupeKey = `${NOTIFIED_PREFIX}${username}:${grant.id}`;
+    const alreadySent = await env.USER_PROFILES.get(dedupeKey);
+    if (alreadySent) continue;
+
+    matches.push({ grant, score });
+  }
+
+  if (!matches.length) return;
+
+  // Sort best-first and cap before queuing.
+  matches.sort((a, b) => b.score - a.score);
+  const topMatches = matches.slice(0, MAX_MATCHES_PER_EMAIL);
+
+  await env.NOTIFY_QUEUE.send({ username, email, matches: topMatches });
+
+  // Mark these grants as notified so they're not re-queued next run.
+  await Promise.all(
+    topMatches.map(({ grant }) =>
+      env.USER_PROFILES.put(
+        `${NOTIFIED_PREFIX}${username}:${grant.id}`,
+        "1",
+        { expirationTtl: NOTIFIED_TTL_SECONDS },
+      )
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Queue handler — NOTIFY_QUEUE consumer → email via Resend
+// ---------------------------------------------------------------------------
+
+async function runQueue(batch, env) {
+  for (const msg of batch.messages) {
+    try {
+      const { username, email, matches } = msg.body;
+      if (!email || !matches?.length) {
+        msg.ack();
+        continue;
+      }
+
+      const { subject, html } = buildEmailSummary(username, matches);
+      await sendEmailViaResend(env.RESEND_API_KEY, email, subject, html);
+      msg.ack();
+    } catch (err) {
+      console.error("profile_matcher: queue handler error", err);
+      msg.retry();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fetchAllGrants(db) {
+  const result = await db
+    .prepare(`SELECT * FROM programs ORDER BY id DESC LIMIT ${GRANT_BATCH_LIMIT}`)
+    .all();
+  return result.results ?? [];
+}
+
+async function loadSelectionIds(env, username) {
+  const raw = await env.USER_PROFILES.get(SELECTIONS_PREFIX + username, "json");
+  if (!Array.isArray(raw)) return new Set();
+  return new Set(raw.map(Number).filter(Number.isFinite));
+}
+
+/**
+ * Lightweight preference learning.
+ *
+ * Inspects the grants a user has explicitly selected (via /api/profile/select-grant)
+ * and nudges their weights toward dimensions that feature in their selections.
+ * Adjustments are capped so the profile can always be overridden by the user.
+ */
+export function refineProfileFromSelections(profile, selectedGrants) {
+  if (!selectedGrants?.length) return profile;
+
+  const total = selectedGrants.length;
+  const stackCount   = selectedGrants.filter(g => g.stack_required === 1).length;
+  const rollingCount = selectedGrants.filter(g =>
+    String(g.cadence || "").toLowerCase().includes("rolling")
+  ).length;
+
+  // Build a sponsor-affinity map for potential future ranking use.
+  const sponsorAffinity = {};
+  for (const g of selectedGrants) {
+    if (g.sponsor) sponsorAffinity[g.sponsor] = (sponsorAffinity[g.sponsor] ?? 0) + 1;
+  }
+
+  const weights = { ...(profile.weights ?? DEFAULT_WEIGHTS) };
+
+  if (stackCount / total > 0.5) {
+    weights.StackAlignment = Math.min(0.25, (weights.StackAlignment ?? 0.1) + 0.05);
+  }
+  if (rollingCount / total > 0.5) {
+    weights.CadenceRecency = Math.min(0.25, (weights.CadenceRecency ?? 0.1) + 0.05);
+  }
+
+  // Renormalize so weights still sum to 1.
+  const sum = Object.values(weights).reduce((a, b) => a + b, 0);
+  if (sum > 0) {
+    for (const k of Object.keys(weights)) weights[k] = weights[k] / sum;
+  }
+
+  return { ...profile, weights, sponsorAffinity };
+}
+
+async function sendEmailViaResend(apiKey, to, subject, html) {
+  if (!apiKey) {
+    console.warn("profile_matcher: RESEND_API_KEY not set — skipping email send");
+    return;
+  }
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: "FoundationPlanner <notifications@foundationplanner.app>",
+      to: [to],
+      subject,
+      html,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Resend API error ${res.status}: ${body}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Worker export
+// ---------------------------------------------------------------------------
+
+export default {
+  async scheduled(_event, env, _ctx) {
+    await runScheduled(env);
+  },
+
+  async queue(batch, env) {
+    await runQueue(batch, env);
+  },
+};

--- a/workers/profile_matcher_wrangler.toml
+++ b/workers/profile_matcher_wrangler.toml
@@ -1,0 +1,38 @@
+name = "grant-profile-matcher"
+main = "workers/profile_matcher_worker.js"
+compatibility_date = "2024-05-29"
+workers_dev = true
+
+[vars]
+# Score threshold (0–10 scale) above which a grant is queued for notification.
+SCORE_THRESHOLD = "6.0"
+
+[triggers]
+# Run daily at 08:00 UTC.
+crons = ["0 8 * * *"]
+
+[[kv_namespaces]]
+binding = "USER_PROFILES"
+id = "3613c184af7d4890a70f1c9d28583329"
+
+[[d1_databases]]
+binding = "GRANT_MANAGER_DB"
+database_name = "grant-manager-db"
+database_id = "e99396be-8043-41f6-9762-07c2b6fc4d3f"
+migrations_dir = "migrations"
+
+[[queues.producers]]
+binding = "NOTIFY_QUEUE"
+queue = "grant-notify-queue"
+
+[[queues.consumers]]
+queue = "grant-notify-queue"
+max_batch_size = 10
+max_batch_timeout = 30
+
+# ── Secrets (must be set before deploying) ──────────────────────────────────
+#
+#   wrangler secret put RESEND_API_KEY -c workers/profile_matcher_wrangler.toml
+#
+# Get a Resend API key at https://resend.com
+# The "from" address must be verified in your Resend account.

--- a/workers/scoring_utils.js
+++ b/workers/scoring_utils.js
@@ -1,0 +1,209 @@
+/**
+ * Scoring utilities shared by the profile matcher worker.
+ *
+ * These are ported directly from worker.js (lines 197–338) so the profile
+ * matcher produces scores identical to what the web app displays.  The
+ * inline copies in worker.js are intentionally left unchanged to avoid
+ * risking the existing web flow.
+ */
+
+export const DEFAULT_WEIGHTS = {
+  Relevance: 0.3,
+  Fit: 0.3,
+  Ease: 0.2,
+  StackAlignment: 0.1,
+  CadenceRecency: 0.1,
+};
+
+export const FOCUS_AREA_KEYWORDS = {
+  "Health & Medicine":         ["health", "medicine", "medical", "clinical", "biomedical", "disease", "drug", "therapeutics", "patient"],
+  "Education & Workforce":     ["education", "workforce", "training", "learning", "student", "school", "academic", "career"],
+  "Technology & Innovation":   ["technology", "innovation", "tech", "software", "digital", "engineering", "data", "ai", "computing"],
+  "Housing & Community":       ["housing", "community", "neighborhood", "affordable", "urban", "rural", "infrastructure"],
+  "Environment & Climate":     ["environment", "climate", "energy", "sustainability", "clean", "emissions", "carbon", "ecology"],
+  "Agriculture & Food":        ["agriculture", "food", "farm", "crop", "nutrition", "rural", "livestock"],
+  "Social Services":           ["social", "welfare", "poverty", "disability", "elderly", "child", "family", "services"],
+  "Arts & Humanities":         ["arts", "humanities", "culture", "museum", "heritage", "creative", "media"],
+  "International Development": ["international", "global", "developing", "foreign", "overseas", "aid"],
+  "Veterans & Military":       ["veteran", "military", "defense", "armed forces", "service member"],
+  "Research & Science":        ["research", "science", "scientific", "laboratory", "study", "investigation"],
+  "Justice & Safety":          ["justice", "safety", "law", "crime", "court", "police", "legal", "equity"],
+};
+
+export const ORG_TYPE_KEYWORDS = {
+  "Nonprofit/NGO":                   ["nonprofit", "ngo", "foundation", "charitable", "501(c)"],
+  "University/Research Institution": ["university", "college", "academic", "institution", "research institution"],
+  "Startup/Small Business":          ["startup", "small business", "entrepreneur", "company", "commercial", "industry"],
+  "Government/Tribal":               ["government", "tribal", "municipality", "state", "federal", "public"],
+  "Individual Researcher":           ["individual", "researcher", "investigator", "pi ", "principal investigator"],
+  "Hospital/Health System":          ["hospital", "health system", "clinic", "medical center"],
+};
+
+export const STAGE_KEYWORDS = {
+  "Early Research / Ideation": ["early", "exploratory", "pilot", "proof of concept", "ideation", "basic research", "preliminary"],
+  "Pilot / Proof of Concept":  ["pilot", "proof of concept", "demonstration", "feasibility"],
+  "Growth / Scaling":          ["scale", "scaling", "expansion", "growth", "replication"],
+  "Established Program":       ["established", "sustained", "continuation", "operational", "ongoing"],
+};
+
+/** Returns a 0–1 match score for how well a grant row fits the user profile. */
+export function computeProfileMatch(r, profile) {
+  const focusAreas = Array.isArray(profile.focusAreas) ? profile.focusAreas : [];
+  const orgType    = profile.orgType  || "";
+  const stage      = profile.stage    || "";
+
+  if (!focusAreas.length && !orgType && !stage) return 0;
+
+  const text = [
+    r.name        || r.Name        || "",
+    r.sponsor     || r.Sponsor     || "",
+    r.benefits    || r.Benefits    || "",
+    r.eligibility_conditions || r["Eligibility (key conditions)"] || "",
+    r.region_eligibility || r["Region / Eligibility"] || "",
+    r.type        || r.Type        || "",
+    r.notes       || r["Notes / Actions"] || "",
+  ].join(" ").toLowerCase();
+
+  let hits = 0, checks = 0;
+
+  if (focusAreas.length) {
+    let areaHits = 0;
+    for (const fa of focusAreas) {
+      const kws = FOCUS_AREA_KEYWORDS[fa] || [];
+      if (kws.some(kw => text.includes(kw))) areaHits++;
+    }
+    checks += focusAreas.length;
+    hits += areaHits;
+  }
+
+  const orgKeywords = ORG_TYPE_KEYWORDS[orgType] || [];
+  if (orgKeywords.length) {
+    checks++;
+    if (orgKeywords.some(kw => text.includes(kw))) hits++;
+  }
+
+  const stageKeywords = STAGE_KEYWORDS[stage] || [];
+  if (stageKeywords.length) {
+    checks++;
+    if (stageKeywords.some(kw => text.includes(kw))) hits++;
+  }
+
+  return checks ? hits / checks : 0;
+}
+
+/** Returns 1.0 if the grant requires the user's stack, else 0.2. */
+export function computeStackAlignment(r) {
+  return (r.stack_required === 1 || r["Stack Required?"] === "Yes") ? 1.0 : 0.2;
+}
+
+/** Returns 0–1 based on deadline proximity; 1.0 for rolling. */
+export function computeCadenceRecency(r) {
+  const cadence = String(r.cadence || r.Cadence || "").toLowerCase();
+  if (cadence.includes("rolling")) return 1.0;
+  const raw = r.deadline || r["Deadline / Next Cohort"];
+  if (!raw) return 0;
+  const deadline = new Date(raw);
+  if (isNaN(deadline.getTime())) return 0;
+  const daysUntil = (deadline.getTime() - Date.now()) / 86400000;
+  if (daysUntil < 0) return 0;
+  return Math.max(0, Math.min(1, 1 - daysUntil / 365));
+}
+
+/**
+ * Returns a 0–10 composite score.
+ *
+ * With a profile: profile match (0–1 → 0–10) is the primary signal;
+ * DB quality scores act as a tiebreaker within the same match tier.
+ * Without a profile: pure DB quality scores scaled to 0–10.
+ */
+export function computeScore(r, weights, profile) {
+  const profileMatch = profile ? computeProfileMatch(r, profile) : 0;
+  const hasProfile = profile && (
+    (Array.isArray(profile.focusAreas) && profile.focusAreas.length) ||
+    profile.orgType || profile.stage
+  );
+
+  const relevance = parseFloat(r.relevance || r.Relevance) || 0;
+  const fit       = parseFloat(r.fit       || r.Fit)       || 0;
+  const ease      = parseFloat(r.ease      || r.Ease)      || 0;
+  const stack     = computeStackAlignment(r);
+  const cadence   = computeCadenceRecency(r);
+
+  if (hasProfile) {
+    const w = weights || DEFAULT_WEIGHTS;
+    const total = Object.values(w).reduce((a, b) => a + b, 0) || 1;
+    const dbScore = ((w.Relevance      ?? 0) / total) * relevance
+                  + ((w.Fit            ?? 0) / total) * fit
+                  + ((w.Ease           ?? 0) / total) * ease
+                  + ((w.StackAlignment ?? 0) / total) * (stack * 3)
+                  + ((w.CadenceRecency ?? 0) / total) * (cadence * 3);
+    return Math.round((profileMatch * 10 + dbScore / 3) * 100) / 100;
+  }
+
+  const w = weights || DEFAULT_WEIGHTS;
+  const total = Object.values(w).reduce((a, b) => a + b, 0) || 1;
+  return Math.round((
+      ((w.Relevance      ?? 0) / total) * relevance
+    + ((w.Fit            ?? 0) / total) * fit
+    + ((w.Ease           ?? 0) / total) * ease
+    + ((w.StackAlignment ?? 0) / total) * (stack * 3)
+    + ((w.CadenceRecency ?? 0) / total) * (cadence * 3)
+  ) * (10 / 3) * 100) / 100;
+}
+
+/**
+ * Builds the HTML body for a grant-match notification email.
+ *
+ * Returns { subject, html } — a pure function, no I/O.
+ */
+export function buildEmailSummary(username, matches) {
+  const count = matches.length;
+  const subject = `${count} new grant match${count === 1 ? "" : "es"} for ${username}`;
+
+  const rows = matches
+    .sort((a, b) => b.score - a.score)
+    .map(({ grant, score }) => {
+      const deadline = grant.deadline
+        ? `<span style="color:#555">Deadline: ${grant.deadline}</span>`
+        : `<span style="color:#888">Rolling / open</span>`;
+      return `
+        <tr>
+          <td style="padding:12px 0;border-bottom:1px solid #eee">
+            <strong style="font-size:15px">${escapeHtml(grant.name || "Unnamed Grant")}</strong>
+            <br>
+            <span style="color:#555">Sponsor: ${escapeHtml(grant.sponsor || "—")}</span>
+            &nbsp;|&nbsp;${deadline}
+            &nbsp;|&nbsp;<strong style="color:#1a56db">Score: ${score.toFixed(1)}</strong>
+          </td>
+        </tr>`;
+    })
+    .join("");
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#111">
+  <h2 style="color:#1a56db">FoundationPlanner: ${count} new grant match${count === 1 ? "" : "es"}</h2>
+  <p>Hello <strong>${escapeHtml(username)}</strong>,</p>
+  <p>We found ${count} new grant opportunit${count === 1 ? "y" : "ies"} matching your profile:</p>
+  <table style="width:100%;border-collapse:collapse">
+    ${rows}
+  </table>
+  <p style="margin-top:24px;font-size:13px;color:#888">
+    Log in to FoundationPlanner to view details, add notes, and track deadlines.<br>
+    To update your notification preferences, visit your profile settings.
+  </p>
+</body>
+</html>`;
+
+  return { subject, html };
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/wrangler.test.toml
+++ b/wrangler.test.toml
@@ -17,5 +17,9 @@ database_name = "grant-manager-test"
 database_id = "00000000-0000-0000-0000-000000000001"
 migrations_dir = "migrations"
 
+[[queues.producers]]
+binding = "NOTIFY_QUEUE"
+queue = "test-notify-queue"
+
 [ai]
 binding = "AI"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,10 +29,6 @@ database_name = "grant-manager-db"
 database_id = "e99396be-8043-41f6-9762-07c2b6fc4d3f"
 migrations_dir = "migrations"
 
-[[queues.producers]]
-binding = "NOTIFY_QUEUE"
-queue = "grant-notify-queue"
-
 [ai]
 binding = "AI"
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,8 @@ command = "cd ui && npm install && npm run build"
 # Comma-separated usernames allowed to use admin features (CSV grant upload).
 # Defaults to "demo" when unset.
 ADMIN_USERS = "demo,asialakay"
+# Score threshold (0–10) used by the profile matcher worker.
+SCORE_THRESHOLD = "6.0"
 
 [[kv_namespaces]]
 binding = "USER_PROFILES"
@@ -26,6 +28,10 @@ binding = "GRANT_MANAGER_DB"
 database_name = "grant-manager-db"
 database_id = "e99396be-8043-41f6-9762-07c2b6fc4d3f"
 migrations_dir = "migrations"
+
+[[queues.producers]]
+binding = "NOTIFY_QUEUE"
+queue = "grant-notify-queue"
 
 [ai]
 binding = "AI"


### PR DESCRIPTION
Part 1 — pytest harness (tests/test_program_scoring.py, 50 tests):
- Covers the full weighted-score formula, all CadenceRecency edge cases
  (rolling, near/far/past/unparseable deadlines, 365-day clamp), StackAlignment
  variants, column aliases, missing-column validation, and null-numeric coercion
- Freezes time at 2026-06-14 via freezegun so deadline assertions stay stable
- Fixes a real bug in program_scoring.py: `pd.to_numeric(x) or 0` did not
  coerce NaN to 0 (NaN is truthy in Python); replaced with explicit pd.isna()
  check so missing/non-numeric Relevance/Fit/Ease fields default to 0.0
- Adds pytest + freezegun to requirements.txt; configures testpaths in
  pyproject.toml; updates package.json test script to run pytest via config

Part 2 — Profile Matcher Worker:
- workers/scoring_utils.js: shared pure scoring functions (computeScore,
  computeProfileMatch, computeStackAlignment, computeCadenceRecency,
  buildEmailSummary) ported from worker.js so the new worker produces
  identical scores to the web dashboard
- workers/profile_matcher_worker.js: cron-triggered Cloudflare Worker that
  lists all user profiles from USER_PROFILES KV, scores every D1 grant for
  each profile, deduplicates via "notified:{user}:{id}" KV keys (30-day TTL),
  queues high-scoring matches (>= SCORE_THRESHOLD) to NOTIFY_QUEUE, and
  consumes that queue to send HTML email summaries via the Resend API
- Preference learning (refineProfileFromSelections): if >50% of a user's
  previously-selected grants are stack-required / rolling-cadence, their
  StackAlignment / CadenceRecency weights get a +0.05 nudge (capped at 0.25,
  renormalized to sum to 1.0), with a sponsorAffinity map attached for future use
- worker.js: adds POST/DELETE /api/profile/select-grant endpoints that store
  selected grant IDs in "selections:{username}" KV (feeds preference learning)
- workers/profile_matcher_wrangler.toml: separate wrangler config with cron
  trigger, NOTIFY_QUEUE producer+consumer, shared KV/D1 bindings; documents
  required "wrangler secret put RESEND_API_KEY" command
- wrangler.toml + wrangler.test.toml: add NOTIFY_QUEUE binding and
  SCORE_THRESHOLD var
- tests/test_profile_matcher.test.js: 31 Vitest tests covering scheduled
  handler (matching, threshold filtering, custom weights, deduplication,
  multi-user, empty-table safety), queue handler (ack-all, missing-email,
  empty-matches), refineProfileFromSelections (pure unit tests), and
  buildEmailSummary (subject, HTML structure, XSS escaping)

All 176 tests pass (50 pytest + 126 vitest).

https://claude.ai/code/session_01QYPXVMtDn4YS1i9x9nriLC