### PR TITLE
Add anonymous feedback widget with GitHub issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,90 @@ Full setup documentation: [DEVELOPERS.md](docs/DEVELOPERS.md)
 
 ---
 
+## Anonymous Feedback (GitHub Issues)
+
+A persistent feedback widget — available on every page without requiring a GitHub account — that files user reports directly as GitHub issues, with optional screenshot attachments.
+
+### How it works
+
+1. The user clicks the **Feedback** button (bottom-right corner, any page).
+2. They fill in a category (Bug Report / Feature Request / General), a message, and optionally their name, email, and a screenshot.
+3. The form `POST`s to `/api/anonymous-feedback` as `multipart/form-data`.
+4. The Cloudflare Worker:
+   - Checks a **KV rate limit** (5 submissions per IP per hour).
+   - If a screenshot is attached, **uploads it to R2** and gets a public URL. If R2 upload fails for any reason, the issue is still created without the image.
+   - Calls the **GitHub Issues API** (`POST /repos/asiakay/grant-manager-tool-demo/issues`) using the `GITHUB_TOKEN` secret, embedding the screenshot as `![Screenshot](url)` in the Markdown body.
+5. The user sees a success confirmation; no GitHub account is needed.
+
+### Setup & deploy
+
+**Required secret**
+
+```bash
+# A GitHub personal access token (classic or fine-grained) with repo Issues write permission
+wrangler secret put GITHUB_TOKEN
+```
+
+**Optional — screenshot uploads**
+
+Screenshots require an R2 bucket with public access enabled and a known public URL:
+
+```bash
+# 1. Create the bucket (already provisioned if you see it in wrangler.toml)
+wrangler r2 bucket create foundationplanner-feedback-attachments
+
+# 2. Enable public access in the Cloudflare dashboard → R2 → bucket → Settings → Public Access
+#    Copy the r2.dev URL (e.g. https://pub-abc123.r2.dev)
+
+# 3. Set the public base URL as a Worker variable
+wrangler secret put FEEDBACK_R2_PUBLIC_BASE_URL
+# Enter: https://pub-abc123.r2.dev/foundationplanner-feedback-attachments
+```
+
+If `FEEDBACK_R2_PUBLIC_BASE_URL` is not set, the widget still works — screenshots are silently skipped and issues are created without images.
+
+### wrangler.toml additions
+
+```toml
+# Rate limiting (KV namespace already provisioned)
+[[kv_namespaces]]
+binding = "FEEDBACK_RATE_LIMIT"
+id = "786a52996c0b4ad4884a48fd10d65d82"
+
+# Screenshot storage (R2 bucket already provisioned)
+[[r2_buckets]]
+binding = "FEEDBACK_ATTACHMENTS"
+bucket_name = "foundationplanner-feedback-attachments"
+```
+
+### Environment variables / secrets
+
+| Name | Required | Description |
+|---|---|---|
+| `GITHUB_TOKEN` | **Yes** | GitHub PAT with `repo` Issues write scope |
+| `FEEDBACK_R2_PUBLIC_BASE_URL` | No | Public base URL of the R2 bucket (enables screenshot embedding) |
+
+### Rate limiting
+
+5 submissions per IP address per hour, enforced via the `FEEDBACK_RATE_LIMIT` KV namespace. Exceeding the limit returns HTTP 429 with a `Retry-After: 3600` header. The counter resets automatically at the top of each hour (KV TTL).
+
+### File upload constraints
+
+- Accepted types: JPEG, PNG, GIF, WebP, AVIF
+- Maximum size: 5 MB
+- Files stored under `feedback/{timestamp}-{uuid}.{ext}` in the R2 bucket
+- Invalid type or oversized files are silently skipped — the issue is still created
+
+### Running tests
+
+```bash
+npm run test:worker
+# or run just the feedback suite:
+npx vitest run tests/anonymous-feedback.test.js
+```
+
+---
+
 ## The Builder
 
 **Asia Grady** is a cooperative economist, civic technologist, and builder based in Jamaica Plain, Boston. She is developing a portfolio of civic infrastructure projects at the intersection of Afrofuturism, cooperative economics, and community wealth — spanning energy, capital access, civic education, and media. She holds published research in urban economics and AI systems.

--- a/tests/anonymous-feedback.test.js
+++ b/tests/anonymous-feedback.test.js
@@ -1,0 +1,445 @@
+import { env, createExecutionContext, waitOnExecutionContext, reset } from "cloudflare:test";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import worker, {
+  checkFeedbackRateLimit,
+  uploadFeedbackScreenshot,
+  buildFeedbackIssueBody,
+} from "../worker.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function workerFetch(request) {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(request, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function feedbackRequest(fields = {}, file = null) {
+  const fd = new FormData();
+  fd.append("message", fields.message ?? "This is test feedback");
+  if (fields.category !== undefined) fd.append("category", fields.category);
+  if (fields.name !== undefined) fd.append("name", fields.name);
+  if (fields.email !== undefined) fd.append("email", fields.email);
+  if (file) fd.append("screenshot", file);
+  return new Request("http://localhost/api/anonymous-feedback", {
+    method: "POST",
+    body: fd,
+    headers: fields.ip ? { "CF-Connecting-IP": fields.ip } : {},
+  });
+}
+
+function mockGitHubOk(issueNumber = 42) {
+  return vi.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({ number: issueNumber, html_url: `https://github.com/owner/repo/issues/${issueNumber}` }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    ),
+  );
+}
+
+function mockGitHubError(status, body = {}) {
+  return vi.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } }),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Schema bootstrap (mirrors worker.test.js pattern)
+// ---------------------------------------------------------------------------
+
+async function createSchema() {
+  const db = env.GRANT_MANAGER_DB;
+  await db.batch([
+    db.prepare(`CREATE TABLE IF NOT EXISTS programs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE
+    )`),
+    db.prepare(`CREATE TABLE IF NOT EXISTS users (
+      username TEXT PRIMARY KEY, password_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL, email TEXT, is_admin INTEGER DEFAULT 0
+    )`),
+    db.prepare(`INSERT OR IGNORE INTO users (username, password_hash, created_at)
+      VALUES ('demo','2a97516c354b68848cdbd8f54a226a0a55b21ed138e207ad6c5cbb9c00aa5aea',0)`),
+    db.prepare(`CREATE TABLE IF NOT EXISTS feedback (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, rating INTEGER NOT NULL,
+      comment TEXT, email TEXT, opted_in INTEGER NOT NULL DEFAULT 0,
+      submitted_at TEXT NOT NULL, user_agent TEXT
+    )`),
+    db.prepare(`CREATE TABLE IF NOT EXISTS subscribers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE, subscribed_at TEXT NOT NULL
+    )`),
+  ]);
+}
+
+beforeEach(reset);
+beforeEach(createSchema);
+afterEach(() => vi.unstubAllGlobals());
+
+// ---------------------------------------------------------------------------
+// Unit: checkFeedbackRateLimit
+// ---------------------------------------------------------------------------
+
+describe("checkFeedbackRateLimit", () => {
+  it("allows the first submission", async () => {
+    const result = await checkFeedbackRateLimit(env, "1.2.3.4");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows up to 5 submissions in the same window", async () => {
+    for (let i = 0; i < 5; i++) {
+      const r = await checkFeedbackRateLimit(env, "1.2.3.4");
+      expect(r.allowed).toBe(true);
+    }
+  });
+
+  it("blocks the 6th submission in the same window", async () => {
+    for (let i = 0; i < 5; i++) {
+      await checkFeedbackRateLimit(env, "1.2.3.4");
+    }
+    const r = await checkFeedbackRateLimit(env, "1.2.3.4");
+    expect(r.allowed).toBe(false);
+  });
+
+  it("tracks different IPs independently", async () => {
+    for (let i = 0; i < 5; i++) await checkFeedbackRateLimit(env, "10.0.0.1");
+    const blocked = await checkFeedbackRateLimit(env, "10.0.0.1");
+    const allowed = await checkFeedbackRateLimit(env, "10.0.0.2");
+    expect(blocked.allowed).toBe(false);
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it("allows submission when FEEDBACK_RATE_LIMIT binding is absent", async () => {
+    const r = await checkFeedbackRateLimit({}, "1.2.3.4");
+    expect(r.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: uploadFeedbackScreenshot
+// ---------------------------------------------------------------------------
+
+describe("uploadFeedbackScreenshot", () => {
+  function makeFile(type = "image/png", size = 1024) {
+    return new File([new Uint8Array(size)], "shot.png", { type });
+  }
+
+  it("uploads a valid image and returns a public URL", async () => {
+    const file = makeFile("image/png", 512);
+    const url = await uploadFeedbackScreenshot(file, env);
+    expect(url).toMatch(/^https:\/\/test-r2\.example\.com\/feedback\/.+\.png$/);
+  });
+
+  it("returns null for disallowed MIME types", async () => {
+    const file = makeFile("application/pdf", 512);
+    const result = await uploadFeedbackScreenshot(file, env);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for files exceeding 5 MB", async () => {
+    const file = makeFile("image/png", 5 * 1024 * 1024 + 1);
+    const result = await uploadFeedbackScreenshot(file, env);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when FEEDBACK_ATTACHMENTS binding is absent", async () => {
+    const file = makeFile("image/jpeg", 512);
+    const result = await uploadFeedbackScreenshot(file, { FEEDBACK_R2_PUBLIC_BASE_URL: "https://x.com" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when FEEDBACK_R2_PUBLIC_BASE_URL is absent", async () => {
+    const file = makeFile("image/jpeg", 512);
+    const { FEEDBACK_R2_PUBLIC_BASE_URL: _, ...envWithoutUrl } = env;
+    const result = await uploadFeedbackScreenshot(file, envWithoutUrl);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when R2 put throws", async () => {
+    const badEnv = {
+      FEEDBACK_R2_PUBLIC_BASE_URL: "https://test-r2.example.com",
+      FEEDBACK_ATTACHMENTS: {
+        put: () => { throw new Error("R2 down"); },
+      },
+    };
+    const file = makeFile("image/png", 512);
+    const result = await uploadFeedbackScreenshot(file, badEnv);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: buildFeedbackIssueBody
+// ---------------------------------------------------------------------------
+
+describe("buildFeedbackIssueBody", () => {
+  it("includes required fields in the output", () => {
+    const body = buildFeedbackIssueBody({
+      name: "Alice",
+      email: "alice@example.com",
+      message: "Something broke",
+      category: "bug",
+      screenshotUrl: null,
+      userAgent: "Mozilla/5.0",
+    });
+    expect(body).toContain("Bug Report");
+    expect(body).toContain("Alice");
+    expect(body).toContain("alice@example.com");
+    expect(body).toContain("Something broke");
+  });
+
+  it("uses Anonymous when name is omitted", () => {
+    const body = buildFeedbackIssueBody({
+      name: null, email: null, message: "Hi", category: "general",
+      screenshotUrl: null, userAgent: null,
+    });
+    expect(body).toContain("_Anonymous_");
+    expect(body).toContain("_Not provided_");
+  });
+
+  it("embeds screenshot as markdown image when URL is provided", () => {
+    const body = buildFeedbackIssueBody({
+      name: null, email: null, message: "See pic", category: "bug",
+      screenshotUrl: "https://cdn.example.com/shot.png", userAgent: null,
+    });
+    expect(body).toContain("![Screenshot](https://cdn.example.com/shot.png)");
+  });
+
+  it("omits screenshot section when URL is null", () => {
+    const body = buildFeedbackIssueBody({
+      name: null, email: null, message: "No pic", category: "general",
+      screenshotUrl: null, userAgent: null,
+    });
+    expect(body).not.toContain("Screenshot");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: POST /api/anonymous-feedback — input validation
+// ---------------------------------------------------------------------------
+
+describe("POST /api/anonymous-feedback — validation", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockGitHubOk());
+  });
+
+  it("rejects a request with no message with 400", async () => {
+    const fd = new FormData();
+    fd.append("category", "bug");
+    const res = await workerFetch(
+      new Request("http://localhost/api/anonymous-feedback", { method: "POST", body: fd }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/message/i);
+  });
+
+  it("rejects a whitespace-only message with 400", async () => {
+    const fd = new FormData();
+    fd.append("message", "   ");
+    const res = await workerFetch(
+      new Request("http://localhost/api/anonymous-feedback", { method: "POST", body: fd }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts valid feedback and returns success with issue number", async () => {
+    const res = await workerFetch(feedbackRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(typeof json.issueNumber).toBe("number");
+  });
+
+  it("accepts all valid categories", async () => {
+    for (const cat of ["bug", "feature", "general"]) {
+      vi.stubGlobal("fetch", mockGitHubOk());
+      const res = await workerFetch(feedbackRequest({ category: cat }));
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("defaults to 'general' for an invalid category", async () => {
+    const mockFetch = mockGitHubOk();
+    vi.stubGlobal("fetch", mockFetch);
+    const res = await workerFetch(feedbackRequest({ category: "invalid" }));
+    expect(res.status).toBe(200);
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody.labels).toContain("feedback");
+  });
+
+  it("truncates messages longer than 5000 chars", async () => {
+    const mockFetch = mockGitHubOk();
+    vi.stubGlobal("fetch", mockFetch);
+    const longMsg = "x".repeat(6000);
+    const res = await workerFetch(feedbackRequest({ message: longMsg }));
+    expect(res.status).toBe(200);
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody.body).toContain("x".repeat(5000));
+    expect(callBody.body).not.toContain("x".repeat(5001));
+  });
+
+  it("returns 503 when GITHUB_TOKEN is not configured", async () => {
+    const { GITHUB_TOKEN: _, ...envWithout } = env;
+    // Override env by accessing without the token — we test via a custom env mock
+    // We directly call the route with a worker that uses an env without GITHUB_TOKEN.
+    // Since we can't swap env per-request easily in the pool, we test via the exported fn.
+    // This test covers the branch via the integration path when token is empty string.
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    // Patch env GITHUB_TOKEN to undefined for this call
+    const origToken = env.GITHUB_TOKEN;
+    Object.defineProperty(env, "GITHUB_TOKEN", { value: undefined, writable: true, configurable: true });
+    const res = await workerFetch(feedbackRequest());
+    expect(res.status).toBe(503);
+    Object.defineProperty(env, "GITHUB_TOKEN", { value: origToken, writable: true, configurable: true });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: rate limiting
+// ---------------------------------------------------------------------------
+
+describe("POST /api/anonymous-feedback — rate limiting", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockGitHubOk());
+  });
+
+  it("allows 5 submissions from the same IP", async () => {
+    for (let i = 0; i < 5; i++) {
+      const res = await workerFetch(feedbackRequest({ ip: "5.5.5.5" }));
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("returns 429 on the 6th submission from the same IP", async () => {
+    for (let i = 0; i < 5; i++) {
+      vi.stubGlobal("fetch", mockGitHubOk());
+      await workerFetch(feedbackRequest({ ip: "6.6.6.6" }));
+    }
+    vi.stubGlobal("fetch", mockGitHubOk());
+    const res = await workerFetch(feedbackRequest({ ip: "6.6.6.6" }));
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/too many/i);
+  });
+
+  it("does not block a different IP after one IP hits limit", async () => {
+    for (let i = 0; i < 5; i++) {
+      vi.stubGlobal("fetch", mockGitHubOk());
+      await workerFetch(feedbackRequest({ ip: "7.7.7.7" }));
+    }
+    vi.stubGlobal("fetch", mockGitHubOk());
+    const res = await workerFetch(feedbackRequest({ ip: "8.8.8.8" }));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: GitHub API error handling
+// ---------------------------------------------------------------------------
+
+describe("POST /api/anonymous-feedback — GitHub error handling", () => {
+  it("returns 503 on GitHub 401", async () => {
+    vi.stubGlobal("fetch", mockGitHubError(401, { message: "Bad credentials" }));
+    const res = await workerFetch(feedbackRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 on GitHub 403", async () => {
+    vi.stubGlobal("fetch", mockGitHubError(403, { message: "Forbidden" }));
+    const res = await workerFetch(feedbackRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 on GitHub 429 (rate limited)", async () => {
+    vi.stubGlobal("fetch", mockGitHubError(429, { message: "API rate limit exceeded" }));
+    const res = await workerFetch(feedbackRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 502 on other GitHub server errors", async () => {
+    vi.stubGlobal("fetch", mockGitHubError(500, { message: "Internal Server Error" }));
+    const res = await workerFetch(feedbackRequest());
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 when GitHub fetch throws a network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")));
+    const res = await workerFetch(feedbackRequest());
+    expect(res.status).toBe(502);
+  });
+
+  it("does not leak internal error details in the response body", async () => {
+    vi.stubGlobal("fetch", mockGitHubError(500, { message: "secret-internal-detail" }));
+    const res = await workerFetch(feedbackRequest());
+    const text = await res.text();
+    expect(text).not.toContain("secret-internal-detail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: screenshot attachment — R2 failure does not block issue creation
+// ---------------------------------------------------------------------------
+
+describe("POST /api/anonymous-feedback — screenshot handling", () => {
+  it("includes screenshot URL in the GitHub issue body when upload succeeds", async () => {
+    const mockFetch = mockGitHubOk();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const img = new File([new Uint8Array(64)], "shot.png", { type: "image/png" });
+    const res = await workerFetch(feedbackRequest({}, img));
+    expect(res.status).toBe(200);
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.body).toContain("![Screenshot]");
+    expect(sentBody.body).toContain("test-r2.example.com");
+  });
+
+  it("creates the issue without a screenshot when upload fails, without returning an error", async () => {
+    // Remove R2 binding so upload returns null
+    const origR2 = env.FEEDBACK_ATTACHMENTS;
+    Object.defineProperty(env, "FEEDBACK_ATTACHMENTS", { value: undefined, writable: true, configurable: true });
+
+    const mockFetch = mockGitHubOk();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const img = new File([new Uint8Array(64)], "shot.png", { type: "image/png" });
+    const res = await workerFetch(feedbackRequest({}, img));
+    expect(res.status).toBe(200);
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.body).not.toContain("![Screenshot]");
+
+    Object.defineProperty(env, "FEEDBACK_ATTACHMENTS", { value: origR2, writable: true, configurable: true });
+  });
+
+  it("rejects files with invalid MIME type (does not block issue creation)", async () => {
+    const mockFetch = mockGitHubOk();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const pdf = new File([new Uint8Array(64)], "file.pdf", { type: "application/pdf" });
+    const res = await workerFetch(feedbackRequest({}, pdf));
+    // Issue still created successfully
+    expect(res.status).toBe(200);
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.body).not.toContain("![Screenshot]");
+  });
+
+  it("rejects files exceeding 5 MB (does not block issue creation)", async () => {
+    const mockFetch = mockGitHubOk();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const big = new File([new Uint8Array(5 * 1024 * 1024 + 1)], "big.png", { type: "image/png" });
+    const res = await workerFetch(feedbackRequest({}, big));
+    expect(res.status).toBe(200);
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.body).not.toContain("![Screenshot]");
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,7 @@ import WelcomePage from "./components/WelcomePage";
 import ForgotPassword from "./components/ForgotPassword";
 import AdminPage from "./components/AdminPage";
 import FeedbackBar from "./components/FeedbackBar";
+import AnonymousFeedbackWidget from "./components/AnonymousFeedbackWidget";
 import { checkAuth, login, fetchProfile, saveProfile, fetchMe, fetchCsrfToken } from "./api";
 import type { UserProfile } from "./api";
 
@@ -115,30 +116,39 @@ export default function App() {
 
   if (auth === "signup") {
     return (
-      <Signup
-        onSuccess={(user, password) => handleSignupSuccess(user, password)}
-        onBackToLogin={() => setAuth("unauthenticated")}
-      />
+      <>
+        <Signup
+          onSuccess={(user, password) => handleSignupSuccess(user, password)}
+          onBackToLogin={() => setAuth("unauthenticated")}
+        />
+        <AnonymousFeedbackWidget />
+      </>
     );
   }
 
   if (auth === "forgot-password") {
     return (
-      <ForgotPassword
-        onBack={() => setAuth("unauthenticated")}
-        onSuccess={() => setAuth("unauthenticated")}
-      />
+      <>
+        <ForgotPassword
+          onBack={() => setAuth("unauthenticated")}
+          onSuccess={() => setAuth("unauthenticated")}
+        />
+        <AnonymousFeedbackWidget />
+      </>
     );
   }
 
   if (auth === "unauthenticated") {
     return (
-      <Login
-        onSuccess={handleLoginSuccess}
-        onDemoSuccess={handleDemoLoginSuccess}
-        onSignUp={() => setAuth("signup")}
-        onForgotPassword={() => setAuth("forgot-password")}
-      />
+      <>
+        <Login
+          onSuccess={handleLoginSuccess}
+          onDemoSuccess={handleDemoLoginSuccess}
+          onSignUp={() => setAuth("signup")}
+          onForgotPassword={() => setAuth("forgot-password")}
+        />
+        <AnonymousFeedbackWidget />
+      </>
     );
   }
 
@@ -152,6 +162,7 @@ export default function App() {
           saving={profileSaving}
         />
         <FeedbackBar />
+        <AnonymousFeedbackWidget />
       </>
     );
   }
@@ -167,6 +178,7 @@ export default function App() {
           saving={profileSaving}
         />
         <FeedbackBar />
+        <AnonymousFeedbackWidget />
       </>
     );
   }
@@ -179,6 +191,7 @@ export default function App() {
           onBack={() => setAuth("authenticated")}
         />
         <FeedbackBar />
+        <AnonymousFeedbackWidget />
       </>
     );
   }
@@ -191,6 +204,7 @@ export default function App() {
         onGoToAdmin={isAdmin ? () => setAuth("admin") : undefined}
       />
       <FeedbackBar />
+      <AnonymousFeedbackWidget />
     </>
   );
 }

--- a/ui/src/components/AnonymousFeedbackWidget.tsx
+++ b/ui/src/components/AnonymousFeedbackWidget.tsx
@@ -1,0 +1,356 @@
+import { useCallback, useRef, useState } from "react";
+
+type Category = "bug" | "feature" | "general";
+
+interface FormState {
+  message: string;
+  category: Category;
+  name: string;
+  email: string;
+}
+
+const MAX_FILE_BYTES = 5 * 1024 * 1024;
+const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp", "image/avif"]);
+
+export default function AnonymousFeedbackWidget() {
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState<FormState>({
+    message: "",
+    category: "general",
+    name: "",
+    email: "",
+  });
+  const [screenshot, setScreenshot] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [fileError, setFileError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  function resetForm() {
+    setForm({ message: "", category: "general", name: "", email: "" });
+    setScreenshot(null);
+    if (preview) URL.revokeObjectURL(preview);
+    setPreview(null);
+    setError("");
+    setFileError("");
+    setSuccess(false);
+  }
+
+  function handleClose() {
+    setOpen(false);
+    if (!success) {
+      // keep form state if not submitted so user doesn't lose work
+    }
+  }
+
+  function handleOpen() {
+    setOpen(true);
+    setError("");
+    setFileError("");
+  }
+
+  function acceptFile(file: File) {
+    setFileError("");
+    if (!ALLOWED_TYPES.has(file.type)) {
+      setFileError("Only images are allowed (JPG, PNG, GIF, WebP, AVIF).");
+      return;
+    }
+    if (file.size > MAX_FILE_BYTES) {
+      setFileError("File is too large. Maximum size is 5 MB.");
+      return;
+    }
+    if (preview) URL.revokeObjectURL(preview);
+    setScreenshot(file);
+    setPreview(URL.createObjectURL(file));
+  }
+
+  function removeScreenshot() {
+    setScreenshot(null);
+    if (preview) URL.revokeObjectURL(preview);
+    setPreview(null);
+    setFileError("");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  const onDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) acceptFile(file);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.message.trim()) {
+      setError("Please describe your feedback before submitting.");
+      return;
+    }
+    setError("");
+    setSubmitting(true);
+
+    const fd = new FormData();
+    fd.append("message", form.message.trim());
+    fd.append("category", form.category);
+    if (form.name.trim()) fd.append("name", form.name.trim());
+    if (form.email.trim()) fd.append("email", form.email.trim());
+    if (screenshot) fd.append("screenshot", screenshot);
+
+    try {
+      const res = await fetch("/api/anonymous-feedback", { method: "POST", body: fd });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(
+          (data as { error?: string }).error ||
+          (res.status === 429
+            ? "Too many submissions. Please try again later."
+            : "Submission failed. Please try again."),
+        );
+        return;
+      }
+      setSuccess(true);
+      setTimeout(() => {
+        setOpen(false);
+        resetForm();
+      }, 2500);
+    } catch {
+      setError("Network error. Please check your connection and try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Floating trigger button */}
+      <button
+        onClick={handleOpen}
+        aria-label="Send feedback"
+        title="Send feedback"
+        className={`fixed bottom-20 right-4 z-40 flex items-center gap-2 px-3 py-2.5 rounded-full bg-brand-600 hover:bg-brand-500 text-white shadow-lg transition-all duration-200 hover:shadow-brand-500/30 hover:shadow-xl text-sm font-medium ${open ? "opacity-0 pointer-events-none" : "opacity-100"}`}
+      >
+        <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+        </svg>
+        <span>Feedback</span>
+      </button>
+
+      {/* Modal backdrop + dialog */}
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Submit feedback"
+        >
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={handleClose}
+          />
+
+          {/* Panel */}
+          <div className="relative w-full max-w-lg bg-gray-900 border border-gray-700 rounded-2xl shadow-2xl flex flex-col max-h-[90vh]">
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-gray-800 shrink-0">
+              <div>
+                <h2 className="text-base font-semibold text-gray-100">Share Feedback</h2>
+                <p className="text-xs text-gray-400 mt-0.5">No account needed — your report becomes a GitHub issue</p>
+              </div>
+              <button
+                onClick={handleClose}
+                className="text-gray-500 hover:text-gray-300 transition-colors p-1 rounded-md hover:bg-gray-800"
+                aria-label="Close"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="overflow-y-auto flex-1 px-5 py-4">
+              {success ? (
+                <div className="flex flex-col items-center justify-center py-8 gap-3">
+                  <div className="w-12 h-12 rounded-full bg-brand-600/20 flex items-center justify-center">
+                    <svg className="w-6 h-6 text-brand-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  </div>
+                  <p className="text-sm font-medium text-gray-200">Feedback submitted — thank you!</p>
+                  <p className="text-xs text-gray-400 text-center">
+                    Your report was filed as a GitHub issue and will be reviewed by the team.
+                  </p>
+                </div>
+              ) : (
+                <form id="anon-feedback-form" onSubmit={handleSubmit} className="space-y-4">
+                  {/* Category */}
+                  <div>
+                    <label className="block text-xs font-medium text-gray-400 mb-1.5">Category</label>
+                    <div className="flex gap-2">
+                      {(["bug", "feature", "general"] as Category[]).map((cat) => (
+                        <button
+                          key={cat}
+                          type="button"
+                          onClick={() => setForm((f) => ({ ...f, category: cat }))}
+                          className={`flex-1 py-1.5 rounded-md text-xs font-medium border transition-colors ${
+                            form.category === cat
+                              ? "bg-brand-600 border-brand-600 text-white"
+                              : "bg-gray-800 border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-300"
+                          }`}
+                        >
+                          {cat === "bug" ? "Bug Report" : cat === "feature" ? "Feature Request" : "General"}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Message */}
+                  <div>
+                    <label htmlFor="anon-msg" className="block text-xs font-medium text-gray-400 mb-1.5">
+                      Message <span className="text-red-400">*</span>
+                    </label>
+                    <textarea
+                      id="anon-msg"
+                      value={form.message}
+                      onChange={(e) => setForm((f) => ({ ...f, message: e.target.value }))}
+                      placeholder={
+                        form.category === "bug"
+                          ? "Describe the bug — what happened and what you expected…"
+                          : form.category === "feature"
+                          ? "Describe the feature you'd like to see…"
+                          : "Share your thoughts, suggestions, or comments…"
+                      }
+                      rows={4}
+                      maxLength={5000}
+                      required
+                      className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2.5 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent resize-none"
+                    />
+                    <p className="text-right text-xs text-gray-600 mt-0.5">{form.message.length}/5000</p>
+                  </div>
+
+                  {/* Screenshot */}
+                  <div>
+                    <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                      Screenshot <span className="text-gray-600">(optional)</span>
+                    </label>
+
+                    {preview ? (
+                      <div className="relative rounded-lg overflow-hidden border border-gray-700">
+                        <img src={preview} alt="Screenshot preview" className="w-full max-h-48 object-contain bg-gray-950" />
+                        <button
+                          type="button"
+                          onClick={removeScreenshot}
+                          className="absolute top-2 right-2 bg-gray-900/80 hover:bg-gray-800 text-gray-300 rounded-full p-1 transition-colors"
+                          aria-label="Remove screenshot"
+                        >
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </div>
+                    ) : (
+                      <div
+                        onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+                        onDragLeave={() => setDragging(false)}
+                        onDrop={onDrop}
+                        onClick={() => fileInputRef.current?.click()}
+                        className={`border-2 border-dashed rounded-lg px-4 py-5 text-center cursor-pointer transition-colors ${
+                          dragging
+                            ? "border-brand-500 bg-brand-500/10"
+                            : "border-gray-700 hover:border-gray-500 hover:bg-gray-800/50"
+                        }`}
+                      >
+                        <svg className="w-6 h-6 text-gray-500 mx-auto mb-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                        <p className="text-xs text-gray-400">
+                          Drag & drop or <span className="text-brand-400">browse</span>
+                        </p>
+                        <p className="text-xs text-gray-600 mt-0.5">PNG, JPG, GIF, WebP — max 5 MB</p>
+                      </div>
+                    )}
+
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/jpeg,image/png,image/gif,image/webp,image/avif"
+                      className="sr-only"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) acceptFile(file);
+                      }}
+                    />
+
+                    {fileError && <p className="text-xs text-red-400 mt-1">{fileError}</p>}
+                  </div>
+
+                  {/* Optional contact info */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label htmlFor="anon-name" className="block text-xs font-medium text-gray-400 mb-1.5">
+                        Name <span className="text-gray-600">(optional)</span>
+                      </label>
+                      <input
+                        id="anon-name"
+                        type="text"
+                        value={form.name}
+                        onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                        placeholder="Your name"
+                        maxLength={100}
+                        className="input"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="anon-email" className="block text-xs font-medium text-gray-400 mb-1.5">
+                        Email <span className="text-gray-600">(optional)</span>
+                      </label>
+                      <input
+                        id="anon-email"
+                        type="email"
+                        value={form.email}
+                        onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
+                        placeholder="For follow-up"
+                        maxLength={255}
+                        className="input"
+                      />
+                    </div>
+                  </div>
+
+                  {error && (
+                    <p className="text-xs text-red-400 bg-red-950/30 border border-red-900/50 rounded-md px-3 py-2">
+                      {error}
+                    </p>
+                  )}
+                </form>
+              )}
+            </div>
+
+            {/* Footer */}
+            {!success && (
+              <div className="flex items-center justify-between px-5 py-4 border-t border-gray-800 shrink-0">
+                <p className="text-xs text-gray-500">
+                  Creates an issue in the{" "}
+                  <span className="text-gray-400">public GitHub repo</span>
+                </p>
+                <button
+                  type="submit"
+                  form="anon-feedback-form"
+                  disabled={submitting || !form.message.trim()}
+                  className="px-4 py-2 text-sm rounded-lg bg-brand-600 hover:bg-brand-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium transition-colors"
+                >
+                  {submitting ? "Submitting…" : "Submit Feedback"}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/worker.js
+++ b/worker.js
@@ -550,6 +550,97 @@ async function syncGrantsWithD1(env, query) {
   return { success: true, inserted: opportunities.length, message: `Successfully loaded ${opportunities.length} active opportunities to local storage.` };
 }
 
+// ===== Anonymous Feedback (GitHub Issues) =====
+
+const FEEDBACK_ALLOWED_MIME = new Set([
+  "image/jpeg", "image/png", "image/gif", "image/webp", "image/avif",
+]);
+const FEEDBACK_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const FEEDBACK_RATE_MAX = 5;
+const FEEDBACK_WINDOW_SECS = 3600; // 1 hour
+
+// Returns { allowed: boolean }. Increments the counter on each allowed call.
+export async function checkFeedbackRateLimit(env, ip) {
+  if (!env.FEEDBACK_RATE_LIMIT) return { allowed: true };
+  const now = Math.floor(Date.now() / 1000);
+  const windowStart = Math.floor(now / FEEDBACK_WINDOW_SECS) * FEEDBACK_WINDOW_SECS;
+  const key = `anon-fb:${ip}:${windowStart}`;
+  const stored = await env.FEEDBACK_RATE_LIMIT.get(key, { type: "json" });
+  const count = stored?.count ?? 0;
+  if (count >= FEEDBACK_RATE_MAX) return { allowed: false };
+  const ttl = windowStart + FEEDBACK_WINDOW_SECS - now + 60;
+  await env.FEEDBACK_RATE_LIMIT.put(
+    key,
+    JSON.stringify({ count: count + 1 }),
+    { expirationTtl: Math.max(ttl, 1) },
+  );
+  return { allowed: true };
+}
+
+// Uploads a screenshot File to R2, returns the public URL or null on failure.
+// A null return must never block issue creation.
+export async function uploadFeedbackScreenshot(file, env) {
+  if (!env.FEEDBACK_ATTACHMENTS || !env.FEEDBACK_R2_PUBLIC_BASE_URL) return null;
+  if (!FEEDBACK_ALLOWED_MIME.has(file.type)) return null;
+  if (file.size > FEEDBACK_MAX_BYTES) return null;
+  try {
+    const rawExt = file.type.split("/")[1] || "bin";
+    const ext = rawExt === "jpeg" ? "jpg" : rawExt;
+    const key = `feedback/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+    const bytes = await file.arrayBuffer();
+    await env.FEEDBACK_ATTACHMENTS.put(key, bytes, {
+      httpMetadata: { contentType: file.type },
+    });
+    const base = env.FEEDBACK_R2_PUBLIC_BASE_URL.replace(/\/$/, "");
+    return `${base}/${key}`;
+  } catch (err) {
+    log("warn", "feedback_r2_upload_failed", { error: String(err) });
+    return null;
+  }
+}
+
+export function buildFeedbackIssueBody({ name, email, message, category, screenshotUrl, userAgent }) {
+  const categoryLabel =
+    category === "bug" ? "Bug Report" :
+    category === "feature" ? "Feature Request" :
+    "General Feedback";
+
+  const rows = [
+    `| Category | ${categoryLabel} |`,
+    `| Submitted | ${new Date().toISOString()} |`,
+    `| Name | ${name || "_Anonymous_"} |`,
+    `| Email | ${email || "_Not provided_"} |`,
+    `| User Agent | ${userAgent ? userAgent.slice(0, 120) : "_Unknown_"} |`,
+  ].join("\n");
+
+  const parts = [
+    `## Feedback Report\n`,
+    `| Field | Value |\n|---|---|\n${rows}\n`,
+    `---\n\n## Message\n\n${message}`,
+  ];
+
+  if (screenshotUrl) {
+    parts.push(`---\n\n## Screenshot\n\n![Screenshot](${screenshotUrl})`);
+  }
+
+  parts.push(`---\n\n_Submitted anonymously via FoundationPlanner feedback form_`);
+  return parts.join("\n\n");
+}
+
+// Thin wrapper so tests can mock the outbound GitHub call without stubbing globalThis.fetch.
+export async function postGitHubIssue(env, payload) {
+  return fetch("https://api.github.com/repos/asiakay/grant-manager-tool-demo/issues", {
+    method: "POST",
+    headers: {
+      Authorization: `token ${env.GITHUB_TOKEN}`,
+      "Content-Type": "application/json",
+      "User-Agent": "FoundationPlanner-FeedbackBot/1.0",
+      Accept: "application/vnd.github.v3+json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
 export default {
   async fetch(request, env, ctx) {
     try {
@@ -1712,6 +1803,118 @@ Respond with ONLY a JSON object, no explanation. Example: {"relevance":2,"fit":1
       return new Response(JSON.stringify({ success: true }), {
         headers: { "Content-Type": "application/json" },
       });
+    }
+
+    // POST /api/anonymous-feedback — no auth required; creates a GitHub issue
+    // Secrets: GITHUB_TOKEN (required), FEEDBACK_R2_PUBLIC_BASE_URL (optional, enables screenshots)
+    if (url.pathname === "/api/anonymous-feedback" && request.method === "POST") {
+      const ip =
+        (request.headers.get("CF-Connecting-IP") ||
+         request.headers.get("X-Forwarded-For")?.split(",")[0]?.trim() ||
+         "unknown");
+
+      const { allowed } = await checkFeedbackRateLimit(env, ip);
+      if (!allowed) {
+        return new Response(
+          JSON.stringify({ error: "Too many submissions. Please try again in an hour." }),
+          { status: 429, headers: { "Content-Type": "application/json", "Retry-After": "3600" } },
+        );
+      }
+
+      let fd;
+      try {
+        fd = await request.formData();
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "Invalid request body" }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      const rawMsg = fd.get("message");
+      if (!rawMsg || typeof rawMsg !== "string" || rawMsg.trim().length === 0) {
+        return new Response(
+          JSON.stringify({ error: "Message is required" }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      const VALID_CATS = ["bug", "feature", "general"];
+      const rawCat = fd.get("category");
+      const category = VALID_CATS.includes(rawCat) ? rawCat : "general";
+      const name     = fd.get("name")  ? String(fd.get("name")).slice(0, 100).trim()  : null;
+      const email    = fd.get("email") ? String(fd.get("email")).slice(0, 255).trim() : null;
+      const message  = rawMsg.slice(0, 5000).trim();
+      const userAgent = request.headers.get("User-Agent") || null;
+
+      // Optional screenshot upload — failure is non-blocking
+      let screenshotUrl = null;
+      const screenshotFile = fd.get("screenshot");
+      if (screenshotFile instanceof File && screenshotFile.size > 0) {
+        screenshotUrl = await uploadFeedbackScreenshot(screenshotFile, env);
+      }
+
+      if (!env.GITHUB_TOKEN) {
+        log("error", "anon_feedback_no_token", reqCtx);
+        return new Response(
+          JSON.stringify({ error: "Feedback service is not configured" }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      const catLabel = category === "bug" ? "bug" : category === "feature" ? "enhancement" : "feedback";
+      const issueTitle =
+        category === "bug"     ? "[Feedback] Bug Report" :
+        category === "feature" ? "[Feedback] Feature Request" :
+                                 "[Feedback] General Feedback";
+      const issueBody = buildFeedbackIssueBody({ name, email, message, category, screenshotUrl, userAgent });
+
+      let ghRes;
+      try {
+        ghRes = await postGitHubIssue(env, {
+          title: issueTitle,
+          body: issueBody,
+          labels: [catLabel, "anonymous-feedback"],
+        });
+      } catch (err) {
+        log("error", "anon_feedback_github_network", { ...reqCtx, error: String(err) });
+        return new Response(
+          JSON.stringify({ error: "Failed to submit feedback. Please try again." }),
+          { status: 502, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (ghRes.status === 401 || ghRes.status === 403) {
+        log("error", "anon_feedback_github_auth", { ...reqCtx, status: ghRes.status });
+        return new Response(
+          JSON.stringify({ error: "Feedback service is temporarily unavailable." }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (ghRes.status === 429) {
+        log("warn", "anon_feedback_github_ratelimit", reqCtx);
+        return new Response(
+          JSON.stringify({ error: "Feedback service is busy. Please try again later." }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (!ghRes.ok) {
+        const errText = await ghRes.text().catch(() => "");
+        log("error", "anon_feedback_github_error", { ...reqCtx, status: ghRes.status, error: errText.slice(0, 200) });
+        return new Response(
+          JSON.stringify({ error: "Failed to submit feedback. Please try again." }),
+          { status: 502, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      const issue = await ghRes.json();
+      log("info", "anon_feedback_submitted", { ...reqCtx, issueNumber: issue.number, category });
+      return new Response(
+        JSON.stringify({ success: true, issueNumber: issue.number }),
+        { headers: { "Content-Type": "application/json" } },
+      );
     }
 
     if (url.pathname === "/logout") {

--- a/wrangler.test.toml
+++ b/wrangler.test.toml
@@ -11,6 +11,18 @@ id = "test-user-profiles"
 binding = "LOGIN_ATTEMPTS"
 id = "test-login-attempts"
 
+[[kv_namespaces]]
+binding = "FEEDBACK_RATE_LIMIT"
+id = "test-feedback-rate-limit"
+
+[[r2_buckets]]
+binding = "FEEDBACK_ATTACHMENTS"
+bucket_name = "test-feedback-attachments"
+
+[vars]
+GITHUB_TOKEN = "test-github-token"
+FEEDBACK_R2_PUBLIC_BASE_URL = "https://test-r2.example.com"
+
 [[d1_databases]]
 binding = "GRANT_MANAGER_DB"
 database_name = "grant-manager-test"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,6 +23,14 @@ id = "3613c184af7d4890a70f1c9d28583329"
 binding = "LOGIN_ATTEMPTS"
 id = "713c8d1d9eb34d1ea13656bf40f14ccc"
 
+[[kv_namespaces]]
+binding = "FEEDBACK_RATE_LIMIT"
+id = "786a52996c0b4ad4884a48fd10d65d82"
+
+[[r2_buckets]]
+binding = "FEEDBACK_ATTACHMENTS"
+bucket_name = "foundationplanner-feedback-attachments"
+
 [[d1_databases]]
 binding = "GRANT_MANAGER_DB"
 database_name = "grant-manager-db"


### PR DESCRIPTION
## Summary

Adds a persistent, unauthenticated feedback widget that allows users to submit bug reports, feature requests, and general feedback from any page. Submissions are automatically filed as GitHub issues with optional screenshot attachments stored in R2.

## Key Changes

- **Anonymous Feedback Widget (React)** (`ui/src/components/AnonymousFeedbackWidget.tsx`)
  - Floating trigger button (bottom-right corner) that opens a modal form
  - Category selection (Bug Report / Feature Request / General)
  - Message textarea with 5000-character limit
  - Optional screenshot upload with drag-and-drop support
  - Optional name and email fields for follow-up contact
  - Client-side validation for file type (JPEG, PNG, GIF, WebP, AVIF) and size (max 5 MB)
  - Success confirmation with auto-close after 2.5 seconds

- **Worker Backend** (`worker.js`)
  - `POST /api/anonymous-feedback` endpoint (no authentication required)
  - `checkFeedbackRateLimit()` — enforces 5 submissions per IP per hour via KV namespace
  - `uploadFeedbackScreenshot()` — uploads images to R2 bucket; returns public URL or null on failure (non-blocking)
  - `buildFeedbackIssueBody()` — formats feedback as Markdown with metadata table and optional screenshot embed
  - `postGitHubIssue()` — wrapper for GitHub API call (testable)
  - Comprehensive error handling: GitHub auth failures (401/403) → 503, GitHub rate limit (429) → 503, network errors → 502
  - Screenshot upload failures are silently skipped; issues are always created

- **Integration Tests** (`tests/anonymous-feedback.test.js`)
  - 445 lines of comprehensive test coverage
  - Unit tests for rate limiting, screenshot upload, and issue body formatting
  - Integration tests for input validation, rate limiting enforcement, GitHub error handling, and screenshot attachment flow
  - Tests verify that R2 failures do not block issue creation

- **Configuration**
  - Added KV namespace binding `FEEDBACK_RATE_LIMIT` to `wrangler.toml` and `wrangler.test.toml`
  - Added R2 bucket binding `FEEDBACK_ATTACHMENTS` to `wrangler.toml` and `wrangler.test.toml`
  - Added environment variables: `GITHUB_TOKEN` (required), `FEEDBACK_R2_PUBLIC_BASE_URL` (optional)

- **UI Integration** (`ui/src/App.tsx`)
  - Mounted `AnonymousFeedbackWidget` on all unauthenticated pages (Login, Signup, Forgot Password)

- **Documentation** (`README.md`)
  - Added "Anonymous Feedback (GitHub Issues)" section with setup instructions, rate limiting details, file constraints, and test commands

## Notable Implementation Details

- **Rate limiting** uses KV with hourly windows; counter resets automatically via TTL
- **Screenshot uploads are non-blocking** — if R2 fails, the issue is still created without the image
- **GitHub API errors** are categorized: auth/permission issues return 503 (service unavailable), other errors return 502 (bad gateway)
- **Form data validation** happens on both client (React) and server (Worker) for defense-in-depth
- **Message truncation** to 5000 characters prevents oversized GitHub issue bodies
- **Markdown formatting** embeds screenshots as `![Screenshot](url)` for inline preview in GitHub

https://claude.ai/code/session_019FnGBMaTwNwYSNzGQe2SUt