### PR TITLE
Improve AI unavailability error handling with status codes

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -127,7 +127,9 @@ export async function sendChat(
       const data = JSON.parse(text);
       if (data.error) msg = data.error;
     } catch { /* not JSON, use raw text */ }
-    throw new Error(msg);
+    const err = new Error(msg) as Error & { status: number };
+    err.status = res.status;
+    throw err;
   }
 
   const contentType = res.headers.get("content-type") || "";

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -169,12 +169,9 @@ export default function ChatPanel({ open, onClose, onGrantLink }: Props) {
       );
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") return;
+      const status = (err as Error & { status?: number }).status;
       const msg = err instanceof Error ? err.message : String(err);
-      if (
-        msg.toLowerCase().includes("ai") ||
-        msg.toLowerCase().includes("binding") ||
-        msg.toLowerCase().includes("not configured")
-      ) {
+      if (status === 503) {
         setAiUnavailable(true);
         setMessages((prev) => prev.slice(0, -1)); // remove empty assistant msg
       } else {

--- a/worker.js
+++ b/worker.js
@@ -1922,7 +1922,7 @@ ${grantCards}
           if (!aiRes.ok) {
             const errText = await aiRes.text().catch(() => "");
             log("error", "ai_rest_failed", { ...reqCtx, status: aiRes.status, error: errText });
-            return jsonResponse(JSON.stringify({ error: `AI request failed (${aiRes.status})` }), { status: 502 });
+            return jsonResponse(JSON.stringify({ error: `The assistant is temporarily unavailable (${aiRes.status}). Please try again.` }), { status: 502 });
           }
           const data = await aiRes.json();
           const text = data.result?.response ?? "";


### PR DESCRIPTION
## Summary
Refactored error handling for AI service failures to use HTTP status codes instead of string matching, providing more reliable detection of service unavailability and better user-facing error messages.

## Key Changes
- **api.ts**: Modified `sendChat()` to attach the HTTP response status code to thrown errors, enabling downstream consumers to check status codes rather than parsing error messages
- **ChatPanel.tsx**: Replaced fragile string-based error detection (checking for "ai", "binding", "not configured") with a direct HTTP 503 status code check
- **worker.js**: Updated error message for failed AI requests to be more user-friendly ("The assistant is temporarily unavailable") while maintaining the status code in the response

## Implementation Details
- Error objects are now typed as `Error & { status?: number }` to safely carry HTTP status information through the error chain
- The worker returns a 502 status when the upstream AI service fails, which is then propagated to the client
- This approach is more maintainable than string matching and less susceptible to breaking if error message text changes

https://claude.ai/code/session_01NzRzHjMUBJs1Yo2YNTz1na