### PR TITLE
Add state funding source scraper framework and Mass.gov implementation

### DIFF
--- a/.github/workflows/state-sources-sync.yml
+++ b/.github/workflows/state-sources-sync.yml
@@ -1,0 +1,48 @@
+name: State Funding Sources Sync
+
+on:
+  schedule:
+    # Weekly Monday 09:00 UTC — one hour after the daily grants-gov-sync (07:00 UTC)
+    # so the profile matcher's 08:00 UTC run sees same-day Grants.gov data first.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  scrape-and-import:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # needed to commit scrape_runs.json back to the branch
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Scrape state sources
+        run: python scripts/scrape_sources.py --all --out out/state_sources.csv
+
+      - name: Import to D1 (remote)
+        run: python import_to_d1.py out/state_sources.csv --env remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Commit scrape run log
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/scrape_runs.json
+          git diff --staged --quiet || git commit -m "chore: update scrape run log [skip ci]"
+          git push

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pyyaml
 certifi
 pytest
 freezegun
+requests
+beautifulsoup4

--- a/scripts/scrape_sources.py
+++ b/scripts/scrape_sources.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""scrape_sources.py — Run one or all state funding source scrapers and write a CSV.
+
+Usage:
+  python scripts/scrape_sources.py --source mass_gov_funding_resources --out out/mass_gov.csv
+  python scripts/scrape_sources.py --all --out out/all_state_sources.csv
+  python scripts/scrape_sources.py --all --out out/all_state_sources.csv --dry-run
+
+The output CSV uses the same column headers as fetch_xml_extract.py, so it flows
+directly into import_to_d1.py without renaming:
+
+  python import_to_d1.py out/all_state_sources.csv --env remote
+
+To add a new source: create sources/<name>.py implementing BaseSource, then add
+one entry to SOURCES below. See sources/README.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Resolve imports whether run from the repo root or via `python scripts/…`
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from sources.base_source import CSV_COLUMNS, ProgramRecord
+from sources.mass_gov_funding import MassGovFundingSource
+
+# Registry: source_id → class. Add one line here to register a new source.
+SOURCES: dict[str, type] = {
+    "mass_gov_funding_resources": MassGovFundingSource,
+}
+
+RUNS_LOG_DEFAULT = _REPO_ROOT / "data" / "scrape_runs.json"
+# Fail if current count drops below this fraction of the last known count.
+ANOMALY_THRESHOLD = 0.5
+# Ignore anomaly check when previous count was this small (new sources / small lists).
+ANOMALY_MIN_BASELINE = 5
+
+
+def load_runs_log(path: Path) -> dict:
+    if path.is_file():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def save_runs_log(path: Path, log: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(log, indent=2) + "\n", encoding="utf-8")
+
+
+def check_anomaly(source_id: str, count: int, log: dict) -> None:
+    """Exit non-zero if count is anomalously low vs. last run."""
+    entry = log.get(source_id, {})
+    last_count = entry.get("row_count", 0)
+    if last_count > ANOMALY_MIN_BASELINE and count < last_count * ANOMALY_THRESHOLD:
+        print(
+            f"ERROR [{source_id}]: Got {count} rows but last run returned {last_count}. "
+            f"This is below the {int(ANOMALY_THRESHOLD*100)}% threshold — possible "
+            f"scrape failure. Fix the source or update data/scrape_runs.json to proceed.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def run_source(source_id: str, cls: type, log: dict, dry_run: bool) -> list[ProgramRecord]:
+    print(f"INFO [{source_id}]: fetching...")
+    instance = cls()
+    try:
+        records = instance.run()
+    except Exception as exc:
+        print(f"ERROR [{source_id}]: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    count = len(records)
+    print(f"INFO [{source_id}]: {count} unique program(s) parsed.")
+
+    if count == 0:
+        print(
+            f"ERROR [{source_id}]: source returned 0 records — possible parse failure.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    check_anomaly(source_id, count, log)
+
+    if not dry_run:
+        log[source_id] = {
+            "last_run": datetime.now(timezone.utc).isoformat(),
+            "row_count": count,
+        }
+
+    return records
+
+
+def write_csv(records: list[ProgramRecord], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        for rec in records:
+            writer.writerow(rec.to_csv_row())
+    print(f"OK: wrote {len(records)} row(s) to {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run state funding source scrapers.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--source", choices=list(SOURCES.keys()), help="Run a single source.")
+    group.add_argument("--all", action="store_true", help="Run all registered sources.")
+    parser.add_argument("--out", required=True, help="Output CSV path.")
+    parser.add_argument(
+        "--runs-log",
+        default=str(RUNS_LOG_DEFAULT),
+        help=f"Path to scrape run log JSON (default: {RUNS_LOG_DEFAULT}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse and print summary but do not write files.",
+    )
+    args = parser.parse_args()
+
+    log_path = Path(args.runs_log)
+    log = load_runs_log(log_path)
+
+    if args.all:
+        to_run = list(SOURCES.items())
+    else:
+        to_run = [(args.source, SOURCES[args.source])]
+
+    all_records: list[ProgramRecord] = []
+    for source_id, cls in to_run:
+        records = run_source(source_id, cls, log, args.dry_run)
+        all_records.extend(records)
+
+    if args.dry_run:
+        print(f"DRY RUN: {len(all_records)} total record(s) — no files written.")
+        return
+
+    write_csv(all_records, Path(args.out))
+    save_runs_log(log_path, log)
+
+
+if __name__ == "__main__":
+    main()

--- a/sources/README.md
+++ b/sources/README.md
@@ -1,0 +1,77 @@
+# Adding a New State Funding Source
+
+Each source is an isolated file in `sources/` that implements `BaseSource`.
+The CSV writer and D1 importer need no changes when a new source is added.
+
+## Steps
+
+1. **Create** `sources/your_source_name.py`:
+
+```python
+from sources.base_source import BaseSource, ProgramRecord
+
+class YourSource(BaseSource):
+    source_id = "your_source_slug"  # used in scrape_runs.json
+
+    def fetch(self) -> str:
+        # Return raw HTML (or JSON string, etc.) for your source page.
+        ...
+
+    def parse(self, raw: str) -> list[ProgramRecord]:
+        # Return one ProgramRecord per unique program.
+        # Deduplicate by name if the page cross-lists programs.
+        ...
+```
+
+2. **Register** it in `scripts/scrape_sources.py`:
+
+```python
+from sources.your_source_name import YourSource
+
+SOURCES = {
+    "mass_gov_funding_resources": MassGovFundingSource,
+    "your_source_slug": YourSource,        # add this line
+}
+```
+
+That's it. Run with:
+
+```bash
+python scripts/scrape_sources.py --source your_source_slug --out out/your_source.csv
+```
+
+## Output contract
+
+`parse()` must return a list of `ProgramRecord` objects. Only `name` and
+`source_url` are required; all other fields default to `""`.
+
+The CSV writer maps `ProgramRecord` fields to column headers that
+`import_to_d1.py` already knows via its `CSV_COLUMN_ALIASES` table:
+
+| ProgramRecord field | CSV column | D1 column |
+|---|---|---|
+| `name` | `Name` | `name` |
+| `source_url` | `Source URL` | `source_url` |
+| `type` | `Type` | `type` |
+| `sponsor` | `Sponsor` | `sponsor` |
+| `categories` | `Categories` | _(dropped — not in D1 schema)_ |
+| `region_eligibility` | `Region / Eligibility` | `region_eligibility` |
+| `deadline_next_cohort` | `Deadline / Next Cohort` | `deadline` |
+| `cadence` | `Cadence` | `cadence` |
+| `benefits` | `Benefits` | `benefits` |
+| `eligibility_key_conditions` | `Eligibility (key conditions)` | `eligibility_conditions` |
+| `stage` | `Stage` | `stage` |
+| `non_dilutive` | `Non-dilutive?` | `non_dilutive` |
+| `stack_required` | `Stack Required?` | `stack_required` |
+| `source_channel` | `Source Channel` | `source_channel` |
+
+`source_channel` defaults to `"state_program"` — override if your source
+warrants a more specific tag.
+
+## Anomaly detection
+
+`scrape_sources.py` tracks row counts in `data/scrape_runs.json`. If a run
+returns fewer than 50% of the previous count (and the previous count was > 5),
+the script exits non-zero and the CI job fails loudly. Update the baseline by
+deleting or editing the entry in `data/scrape_runs.json` when a source
+legitimately shrinks.

--- a/sources/base_source.py
+++ b/sources/base_source.py
@@ -1,0 +1,98 @@
+"""Base interface every state funding source must implement.
+
+To add a new source:
+  1. Subclass BaseSource in a new file under sources/
+  2. Implement fetch() and parse()
+  3. Register in scripts/scrape_sources.py SOURCES dict
+
+See sources/README.md for the full walkthrough.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+# CSV column headers — matches fetch_xml_extract.py's output so import_to_d1.py
+# resolves them via its existing CSV_COLUMN_ALIASES table without any changes.
+# "Categories" has no D1 column; import_to_d1.py silently drops unknown columns.
+CSV_COLUMNS = [
+    "Type",
+    "Name",
+    "Sponsor",
+    "Source URL",
+    "Categories",
+    "Region / Eligibility",
+    "Deadline / Next Cohort",
+    "Cadence",
+    "Benefits",
+    "Eligibility (key conditions)",
+    "Stage",
+    "Non-dilutive?",
+    "Stack Required?",
+    "Relevance",
+    "Fit",
+    "Ease",
+    "Source Channel",
+]
+
+
+@dataclass
+class ProgramRecord:
+    """One row in the output CSV, one program in D1."""
+
+    name: str
+    source_url: str
+    type: str = ""
+    sponsor: str = ""
+    categories: str = ""  # comma-joined; used for dedup transparency, dropped by import_to_d1.py
+    region_eligibility: str = ""
+    deadline_next_cohort: str = ""
+    cadence: str = ""
+    benefits: str = ""
+    eligibility_key_conditions: str = ""
+    stage: str = ""
+    non_dilutive: str = ""
+    stack_required: str = ""
+    relevance: str = ""
+    fit: str = ""
+    ease: str = ""
+    source_channel: str = "state_program"
+
+    def to_csv_row(self) -> dict:
+        return {
+            "Type": self.type,
+            "Name": self.name,
+            "Sponsor": self.sponsor,
+            "Source URL": self.source_url,
+            "Categories": self.categories,
+            "Region / Eligibility": self.region_eligibility,
+            "Deadline / Next Cohort": self.deadline_next_cohort,
+            "Cadence": self.cadence,
+            "Benefits": self.benefits,
+            "Eligibility (key conditions)": self.eligibility_key_conditions,
+            "Stage": self.stage,
+            "Non-dilutive?": self.non_dilutive,
+            "Stack Required?": self.stack_required,
+            "Relevance": self.relevance,
+            "Fit": self.fit,
+            "Ease": self.ease,
+            "Source Channel": self.source_channel,
+        }
+
+
+class BaseSource(ABC):
+    """Abstract base for all state funding sources."""
+
+    source_id: str  # stable slug used as the key in SOURCES and scrape_runs.json
+
+    @abstractmethod
+    def fetch(self) -> str:
+        """Return raw HTML/content for this source."""
+
+    @abstractmethod
+    def parse(self, raw: str) -> list[ProgramRecord]:
+        """Parse raw content into ProgramRecords."""
+
+    def run(self) -> list[ProgramRecord]:
+        return self.parse(self.fetch())

--- a/sources/mass_gov_funding.py
+++ b/sources/mass_gov_funding.py
@@ -1,0 +1,163 @@
+"""Scraper for https://www.mass.gov/lists/funding-resources.
+
+The page lists Massachusetts state funding programs organized under <h2>
+category headings. Programs cross-listed under multiple categories get a
+single row with categories comma-joined — dedup is by program name (lowercased,
+stripped), matching how import_to_d1.py upserts on the `name` UNIQUE constraint.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup, Tag
+
+from sources.base_source import BaseSource, ProgramRecord
+
+SOURCE_URL = "https://www.mass.gov/lists/funding-resources"
+
+# Subset of category heading text → program type.
+# Match is substring, case-insensitive; first match wins.
+_CATEGORY_TYPE_MAP = [
+    ("tax credit", "Tax Credit"),
+    ("tax incentive", "Tax Credit"),
+    ("job incentive", "Tax Credit"),
+    ("grant", "Grant"),
+    ("venture capital", "Grant"),
+    ("technical assistance", "Technical Assistance"),
+    # "working capital" before "bond" so mixed categories like
+    # "Working Capital, Bonds & Loans" default to Loan not Bond.
+    ("working capital", "Loan"),
+    ("real estate", "Loan"),
+    ("equipment", "Loan"),
+    ("acquiring", "Loan"),
+    ("constructing", "Loan"),
+    ("renovating", "Loan"),
+    ("bond", "Bond"),
+    ("loan", "Loan"),
+]
+
+# Known administering agencies to extract from description text.
+_AGENCY_PATTERNS = [
+    (re.compile(r"\bMassCEC\b", re.I), "MassCEC"),
+    (re.compile(r"\bMass(?:achusetts)?\s+Clean\s+Energy\b", re.I), "MassCEC"),
+    (re.compile(r"\bMassDevelopment\b", re.I), "MassDevelopment"),
+    (re.compile(r"\bMassTech\b", re.I), "MassTech"),
+    (re.compile(r"\bMLSC\b"), "MLSC"),
+    (re.compile(r"\bMass(?:achusetts)?\s+Life\s+Sciences\b", re.I), "MLSC"),
+    (re.compile(r"\bMassVentures\b", re.I), "MassVentures"),
+    (re.compile(r"\bMass\s+Ventures\b", re.I), "MassVentures"),
+]
+
+_DEFAULT_SPONSOR = "Commonwealth of Massachusetts"
+
+
+def _infer_type(category_text: str) -> str:
+    lower = category_text.lower()
+    for fragment, program_type in _CATEGORY_TYPE_MAP:
+        if fragment in lower:
+            return program_type
+    return "Program"
+
+
+def _extract_sponsor(text: str) -> str:
+    for pattern, name in _AGENCY_PATTERNS:
+        if pattern.search(text):
+            return name
+    return _DEFAULT_SPONSOR
+
+
+class MassGovFundingSource(BaseSource):
+    source_id = "mass_gov_funding_resources"
+
+    def fetch(self) -> str:
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (compatible; grant-manager-bot/1.0; "
+                "+https://github.com/asiakay/grant-manager-tool-demo)"
+            )
+        }
+        resp = requests.get(SOURCE_URL, headers=headers, timeout=30)
+        resp.raise_for_status()
+        return resp.text
+
+    def parse(self, raw: str) -> list[ProgramRecord]:
+        soup = BeautifulSoup(raw, "html.parser")
+
+        # Keyed by normalized name so cross-listed programs merge into one row.
+        records: dict[str, ProgramRecord] = {}
+
+        # Walk every <h2> on the page; collect links that follow it until the
+        # next <h2>. mass.gov uses a flat structure: h2 → sibling ul/div with
+        # anchors inside. We use next_siblings to stay robust to minor CMS changes.
+        for heading in soup.find_all("h2"):
+            category = heading.get_text(strip=True)
+            if not category:
+                continue
+            program_type = _infer_type(category)
+
+            # Gather all <a> tags in siblings until the next h2.
+            for sibling in heading.next_siblings:
+                if isinstance(sibling, Tag):
+                    if sibling.name == "h2":
+                        break
+                    for anchor in sibling.find_all("a", href=True):
+                        self._process_anchor(anchor, category, program_type, records)
+
+        return list(records.values())
+
+    def _process_anchor(
+        self,
+        anchor: Tag,
+        category: str,
+        program_type: str,
+        records: dict[str, ProgramRecord],
+    ) -> None:
+        name = anchor.get_text(strip=True)
+        if not name:
+            return
+
+        href = anchor["href"]
+        # Skip page-internal fragment links and non-program anchors.
+        if href.startswith("#") or not href.strip():
+            return
+
+        url = urljoin(SOURCE_URL, href)
+
+        # Pull description from the nearest sibling <p> or parent container text.
+        description = ""
+        parent = anchor.parent
+        if parent:
+            # Try the next <p> sibling of the anchor's parent.
+            next_p = parent.find_next_sibling("p")
+            if next_p:
+                description = next_p.get_text(strip=True)
+            if not description:
+                # Fallback: text of the anchor's own container.
+                description = parent.get_text(separator=" ", strip=True)
+
+        sponsor = _extract_sponsor(description)
+        key = name.lower().strip()
+
+        if key in records:
+            existing = records[key]
+            if category not in existing.categories.split(", "):
+                existing.categories = (
+                    f"{existing.categories}, {category}"
+                    if existing.categories
+                    else category
+                )
+            # Prefer a more specific sponsor if we found one.
+            if existing.sponsor == _DEFAULT_SPONSOR and sponsor != _DEFAULT_SPONSOR:
+                existing.sponsor = sponsor
+        else:
+            records[key] = ProgramRecord(
+                name=name,
+                source_url=url,
+                type=program_type,
+                sponsor=sponsor,
+                categories=category,
+                benefits=description[:500] if description else "",
+            )


### PR DESCRIPTION
## Summary

This PR introduces a pluggable scraper framework for state funding programs and implements the first source: Massachusetts state funding resources from mass.gov. The framework enables easy addition of new state sources without modifying the CSV writer or D1 importer.

## Key Changes

- **Base framework** (`sources/base_source.py`): Abstract `BaseSource` class defining the interface all sources must implement (`fetch()` and `parse()`), plus `ProgramRecord` dataclass that maps to the existing D1 schema via CSV columns.

- **Mass.gov scraper** (`sources/mass_gov_funding.py`): Concrete implementation that:
  - Scrapes https://www.mass.gov/lists/funding-resources
  - Parses programs organized under `<h2>` category headings
  - Deduplicates cross-listed programs by normalized name
  - Infers program type (Grant, Loan, Bond, Tax Credit, etc.) from category text
  - Extracts administering agency (MassCEC, MassDevelopment, etc.) from descriptions via regex patterns
  - Handles malformed HTML robustly using sibling traversal

- **Scraper CLI** (`scripts/scrape_sources.py`): Command-line tool that:
  - Runs one or all registered sources
  - Writes output CSV compatible with existing `import_to_d1.py`
  - Tracks row counts in `data/scrape_runs.json` for anomaly detection (fails if count drops below 50% of baseline)
  - Supports `--dry-run` mode for testing

- **CI/CD workflow** (`.github/workflows/state-sources-sync.yml`): Weekly scheduled job that:
  - Runs all scrapers
  - Imports results to D1 (remote)
  - Commits updated scrape run log back to the repo

- **Documentation** (`sources/README.md`): Step-by-step guide for adding new sources, including the output contract and field mappings to D1.

## Notable Implementation Details

- **Deduplication**: Programs cross-listed under multiple categories are merged into a single row with comma-joined categories, matching how `import_to_d1.py` upserts on the `name` UNIQUE constraint.
- **Type inference**: Uses a priority-ordered substring match against category headings (e.g., "working capital" before "bond" to prefer Loan over Bond for mixed categories).
- **Sponsor extraction**: Regex patterns recognize common Massachusetts agency abbreviations and full names, falling back to "Commonwealth of Massachusetts" if no match.
- **Anomaly detection**: Prevents silent scrape failures by comparing row counts against historical baseline; requires explicit opt-in to proceed if count drops significantly.
- **CSV compatibility**: Output columns and field names align with existing `CSV_COLUMN_ALIASES` in `import_to_d1.py`, so no changes needed there.

https://claude.ai/code/session_01SbuyV3y8UXGCXtdrhNEW6C