### PR TITLE
Add custom domains configuration for grantmatch.dev

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,12 @@ main = "worker.js"
 compatibility_date = "2024-05-29"
 workers_dev = true
 
+[[custom_domains]]
+pattern = "grantmatch.dev"
+
+[[custom_domains]]
+pattern = "www.grantmatch.dev"
+
 assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
 
 [build]


### PR DESCRIPTION
## Summary
Added custom domain configuration to the Wrangler worker to enable the application to be served from the grantmatch.dev domain and its www subdomain.

## Changes
- Configured two custom domain patterns in `wrangler.toml`:
  - `grantmatch.dev` (root domain)
  - `www.grantmatch.dev` (www subdomain)

## Details
These custom domain entries allow the Cloudflare Worker to respond to requests on both the root domain and www subdomain, enabling proper DNS routing and SSL/TLS certificate handling for the GrantMatch application.

https://claude.ai/code/session_019ULHX8k1LhBrUtNKQZzuxH