### PR TITLE
Fix custom domain config: use [[routes]] with custom_domain = true

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,11 +3,13 @@ main = "worker.js"
 compatibility_date = "2024-05-29"
 workers_dev = true
 
-[[custom_domains]]
+[[routes]]
 pattern = "grantmatch.dev"
+custom_domain = true
 
-[[custom_domains]]
+[[routes]]
 pattern = "www.grantmatch.dev"
+custom_domain = true
 
 assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,8 @@ main = "worker.js"
 compatibility_date = "2024-05-29"
 workers_dev = true
 
+assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
+
 [[routes]]
 pattern = "grantmatch.dev"
 custom_domain = true
@@ -10,8 +12,6 @@ custom_domain = true
 [[routes]]
 pattern = "www.grantmatch.dev"
 custom_domain = true
-
-assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
 
 [build]
 command = "cd ui && npm install && npm run build"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,12 @@ main = "worker.js"
 compatibility_date = "2024-05-29"
 workers_dev = true
 
+[[custom_domains]]
+pattern = "grantmatch.dev"
+
+[[custom_domains]]
+pattern = "www.grantmatch.dev"
+
 assets = { directory = "ui/dist", not_found_handling = "single-page-application", binding = "ASSETS" }
 
 [build]


### PR DESCRIPTION
## What happened

PR #290 was merged before a Codex review fix was pushed. As a result, `main` ended up with `[[custom_domains]]` — which wrangler 4.x silently ignores as an unknown field. The deploy succeeded but registered no custom domains, so `grantmatch.dev` never resolved.

**Evidence from the deploy logs of #290's merge:**
```
▲ [WARNING] Processing wrangler.toml configuration:
    - Unexpected fields found in top-level field: "custom_domains"
```
Deployed triggers only listed `workers.dev` — no `grantmatch.dev`.

## What this fixes

Replaces `[[custom_domains]]` with the correct `[[routes]]` + `custom_domain = true` form (verified against wrangler 4.x config schema `CustomDomainRoute`):

```toml
[[routes]]
pattern = "grantmatch.dev"
custom_domain = true

[[routes]]
pattern = "www.grantmatch.dev"
custom_domain = true
```

No `zone_name` or `zone_id` needed — `custom_domain = true` auto-discovers the zone from the account.

## After merging

When CI runs `wrangler deploy`, wrangler will register both domains as custom domain routes, auto-create the Cloudflare DNS records, and provision SSL. No manual DNS entries needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ULHX8k1LhBrUtNKQZzuxH)_