### PR TITLE
Implement PDF processing pipeline with FastAPI summarizer service

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -123,3 +123,42 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+
+      - name: Create pdf-ingest queue (idempotent)
+        run: npx wrangler queues create pdf-ingest || echo "Queue already exists — continuing"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Create foundationplanner-pdfs R2 bucket (idempotent)
+        run: npx wrangler r2 bucket create foundationplanner-pdfs || echo "Bucket already exists — continuing"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy pdf processor worker
+        # Skipped until GRANT_SUMMARIZER_URL is set as a repo secret.
+        # See grant_summarizer/server.py and workers/pdf_wrangler.toml for setup.
+        run: |
+          if [ -z "$GRANT_SUMMARIZER_URL" ]; then
+            echo "GRANT_SUMMARIZER_URL not set — skipping pdf-worker deploy" >&2
+            exit 0
+          fi
+          npx wrangler deploy -c workers/pdf_wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GRANT_SUMMARIZER_URL: ${{ secrets.GRANT_SUMMARIZER_URL }}
+
+      - name: Set pdf worker secrets
+        run: |
+          if [ -z "$GRANT_SUMMARIZER_URL" ]; then
+            echo "GRANT_SUMMARIZER_URL not set — pdf worker secrets skipped" >&2
+            exit 0
+          fi
+          jq -n --arg url "$GRANT_SUMMARIZER_URL" '{"GRANT_SUMMARIZER_URL": $url}' \
+            | npx wrangler secret bulk -c workers/pdf_wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GRANT_SUMMARIZER_URL: ${{ secrets.GRANT_SUMMARIZER_URL }}

--- a/README.md
+++ b/README.md
@@ -201,8 +201,58 @@ Full setup documentation: [DEVELOPERS.md](docs/DEVELOPERS.md)
 
 ## Roadmap
 
-- **PDF processing pipeline** — A Queue-based worker ([`drafts/pdf_worker.ts`](drafts/pdf_worker.ts)) ingests grant PDFs from R2 via `grant_summarizer` and imports scored rows into D1. Prototyped; pending hosted `GRANT_SUMMARIZER_URL` and Cloudflare Queue provisioning.
+- **PDF processing pipeline** — Implemented. The [`grant_summarizer/server.py`](grant_summarizer/server.py) FastAPI service wraps the existing extraction + normalization package into a single `POST /summarize` endpoint. [`workers/pdf_wrangler.toml`](workers/pdf_wrangler.toml) deploys the Queue consumer ([`drafts/pdf_worker.ts`](drafts/pdf_worker.ts)) that picks up R2-uploaded PDFs, calls the service, and writes CSV + Markdown back to R2. CI provisions the `pdf-ingest` queue and `foundationplanner-pdfs` bucket on every deploy. **Remaining step:** host the FastAPI service and add `GRANT_SUMMARIZER_URL` as a repo secret — see [PDF Pipeline setup](#pdf-pipeline) below.
 - ~~**Grants.gov XML Extract ingestion**~~ — Shipped: `fetch_xml_extract.py` pulls the full daily catalog (including forecasted opportunities) into the same pipeline that already scores and imports keyword-search results, with structured award/eligibility/CFDA fields now surfaced in the UI.
+
+---
+
+## PDF Pipeline
+
+The pipeline goes: **R2 PDF upload → `pdf-ingest` queue message → `grant-pdf-processor` Worker → `grant_summarizer/server.py` → CSV + Markdown written back to R2**.
+
+### 1. Host the summarizer service
+
+`grant_summarizer/server.py` is a FastAPI app that accepts raw PDF bytes and returns structured data. Host it anywhere Python runs — Render, Railway, fly.io, or Hugging Face Spaces all work.
+
+```bash
+# Install with server extras
+pip install -e "grant_summarizer[server]"
+
+# Run locally (for testing)
+uvicorn grant_summarizer.server:app --port 8000
+# POST http://localhost:8000/summarize  ← GRANT_SUMMARIZER_URL
+
+# Health check
+curl http://localhost:8000/health
+```
+
+The endpoint accepts raw PDF bytes (`Content-Type: application/pdf`) and returns:
+```json
+{ "csv": "<header row>\n<data row>\n", "markdown": "# Grant Name\n..." }
+```
+
+### 2. Set the repo secret
+
+Once the service is hosted, add `GRANT_SUMMARIZER_URL` (pointing to the `/summarize` path) as a GitHub Actions repo secret. The next push to `main` will deploy the `grant-pdf-processor` Worker and wire the secret in.
+
+```bash
+# Or set it directly via wrangler:
+wrangler secret put GRANT_SUMMARIZER_URL -c workers/pdf_wrangler.toml
+```
+
+### 3. Enqueue a PDF
+
+Upload a PDF to the `foundationplanner-pdfs` R2 bucket and send its key as a queue message:
+
+```bash
+# Upload
+wrangler r2 object put foundationplanner-pdfs/mygrant.pdf --file mygrant.pdf
+
+# Enqueue (the Worker picks it up within seconds)
+wrangler queues send pdf-ingest '{"key":"mygrant.pdf"}'
+```
+
+The Worker writes `mygrant.csv` and `mygrant.md` back to the same bucket.
 
 ---
 

--- a/grant_summarizer/pyproject.toml
+++ b/grant_summarizer/pyproject.toml
@@ -17,3 +17,4 @@ grant-summarizer = "grant_summarizer.cli:main"
 
 [project.optional-dependencies]
 test = ["pytest"]
+server = ["fastapi>=0.111", "uvicorn[standard]>=0.29"]

--- a/grant_summarizer/server.py
+++ b/grant_summarizer/server.py
@@ -1,0 +1,52 @@
+import csv
+import io
+import os
+import tempfile
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .extract import extract_text, find_field_windows
+from .normalize import normalize_fields
+from .summarize import one_pager_md
+
+app = FastAPI(title="Grant Summarizer")
+
+
+@app.post("/summarize")
+async def summarize(request: Request) -> JSONResponse:
+    """Accept raw PDF bytes, return {"csv": "...", "markdown": "..."}."""
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="Empty request body — send raw PDF bytes")
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(body)
+            tmp_path = tmp.name
+
+        text = extract_text(tmp_path)
+        windows = find_field_windows(text)
+        row = normalize_fields(windows)
+
+        buf = io.StringIO()
+        data = row.model_dump()
+        writer = csv.DictWriter(buf, fieldnames=data.keys())
+        writer.writeheader()
+        writer.writerow(data)
+        csv_str = buf.getvalue()
+
+        md_str = one_pager_md(row)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    return JSONResponse({"csv": csv_str, "markdown": md_str})
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok"}

--- a/workers/pdf_wrangler.toml
+++ b/workers/pdf_wrangler.toml
@@ -1,0 +1,30 @@
+name = "grant-pdf-processor"
+main = "../drafts/pdf_worker.ts"
+compatibility_date = "2024-05-29"
+workers_dev = true
+
+[[r2_buckets]]
+binding = "PDF_BUCKET"
+bucket_name = "foundationplanner-pdfs"
+
+[[queues.consumers]]
+queue = "pdf-ingest"
+max_batch_size = 10
+max_batch_timeout = 30
+
+# Uncomment to forward scored CSV keys to a downstream scoring queue:
+# [[queues.producers]]
+# binding = "SCORE_QUEUE"
+# queue = "grant-score-queue"
+
+# ── Secrets (set before deploying) ──────────────────────────────────────────
+#
+#   wrangler secret put GRANT_SUMMARIZER_URL -c workers/pdf_wrangler.toml
+#
+# Point this at your deployed grant_summarizer/server.py instance.
+# Free hosting options: Render, Railway, Hugging Face Spaces, fly.io.
+#
+# To run locally for testing:
+#   pip install -e "grant_summarizer[server]"
+#   uvicorn grant_summarizer.server:app --port 8000
+# then set GRANT_SUMMARIZER_URL = "http://localhost:8000/summarize"


### PR DESCRIPTION
## Summary
Completes the PDF processing pipeline by implementing a FastAPI service wrapper around the existing grant extraction and normalization logic, along with CI/CD infrastructure to deploy the queue consumer Worker and provision required Cloudflare resources.

## Key Changes

- **FastAPI summarizer service** (`grant_summarizer/server.py`): New service that wraps existing `extract_text`, `find_field_windows`, `normalize_fields`, and `one_pager_md` functions into a single `/summarize` endpoint accepting raw PDF bytes and returning structured CSV and Markdown output. Includes a `/health` endpoint for monitoring.

- **Worker configuration** (`workers/pdf_wrangler.toml`): New Wrangler config for the `grant-pdf-processor` Worker that consumes messages from the `pdf-ingest` queue, binds to the `foundationplanner-pdfs` R2 bucket, and includes setup instructions for the `GRANT_SUMMARIZER_URL` secret.

- **CI/CD pipeline enhancements** (`.github/workflows/workers-ci.yml`): 
  - Idempotent queue and bucket provisioning steps
  - Conditional Worker deployment that only runs when `GRANT_SUMMARIZER_URL` secret is configured
  - Secret injection for the deployed Worker

- **Dependencies** (`grant_summarizer/pyproject.toml`): Added optional `server` extras group with FastAPI and Uvicorn for hosting the summarizer service.

- **Documentation** (README.md): Added comprehensive "PDF Pipeline" section with setup instructions for hosting the service, setting repo secrets, and enqueuing PDFs for processing.

## Implementation Details

- The FastAPI service uses temporary files to handle raw PDF bytes, ensuring cleanup even on errors
- CI deployment is gracefully skipped if `GRANT_SUMMARIZER_URL` is not yet configured, allowing incremental setup
- The pipeline is designed to be deployment-agnostic (Render, Railway, fly.io, Hugging Face Spaces all supported)
- Queue consumer configuration allows batching up to 10 messages with a 30-second timeout for efficiency

https://claude.ai/code/session_01NbqbNgTRjiP9UZHfv8TcVo