### PR TITLE
Add Simpler Grants.gov API integration with live scan endpoint

### DIFF
--- a/.github/workflows/grants-gov-sync.yml
+++ b/.github/workflows/grants-gov-sync.yml
@@ -38,6 +38,15 @@ jobs:
             --output data/csvs/grants_gov_extract.csv \
             ${{ github.event.inputs.date && format('--date {0}', github.event.inputs.date) || '' }}
 
+      - name: Fetch API extract (Simpler Grants.gov)
+        continue-on-error: true
+        run: |
+          python fetch_grants_api.py \
+            --output data/csvs/grants_gov_api.csv \
+            --status both
+        env:
+          SIMPLER_GRANTS_API_KEY: ${{ secrets.SIMPLER_GRANTS_API_KEY }}
+
       - name: Wrangle
         run: python scripts/wrangle_grants.py --input data/csvs --out out/master.csv --print-summary
 

--- a/fetch_grants_api.py
+++ b/fetch_grants_api.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Fetch grant opportunities from the Simpler Grants.gov API into a pipeline-compatible CSV.
+
+Produces the same column schema as fetch_xml_extract.py so wrangle_grants.py,
+program_scoring.py, and import_to_d1.py can consume both files without changes.
+
+Usage:
+  python fetch_grants_api.py
+  python fetch_grants_api.py --limit 50 --debug
+  python fetch_grants_api.py --agency-code DOE --agency-code EPA --min-award 50000
+  python fetch_grants_api.py --status posted --deadline-before 2026-12-31
+
+Requires: SIMPLER_GRANTS_API_KEY environment variable.
+  Register at https://simpler.grants.gov to obtain a free API key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from typing import Dict, Iterator, List, Optional
+
+import certifi
+
+from fetch_xml_extract import OUTPUT_COLUMNS, _derive_relevance, _fmt_award
+
+SIMPLER_API_URL = "https://api.simpler.grants.gov/v1/opportunities/search"
+DEFAULT_OUTPUT = "data/csvs/grants_gov_api.csv"
+PAGE_SIZE = 100
+MAX_OPPORTUNITIES = 2000
+
+
+def build_filter_body(
+    agency_codes: Optional[List[str]],
+    min_award: Optional[float],
+    max_award: Optional[float],
+    deadline_before: Optional[str],
+    status: str,
+) -> Dict:
+    """Return the filters dict for the Simpler Grants.gov API POST body."""
+    filters: Dict = {
+        "funding_instrument": {"one_of": ["grant", "cooperative_agreement"]},
+    }
+
+    if status == "posted":
+        filters["opportunity_status"] = {"one_of": ["posted"]}
+    elif status == "forecasted":
+        filters["opportunity_status"] = {"one_of": ["forecasted"]}
+    else:
+        filters["opportunity_status"] = {"one_of": ["posted", "forecasted"]}
+
+    if agency_codes:
+        filters["agency"] = {"one_of": agency_codes}
+
+    # award_ceiling.min: ceiling can reach min_award (mirrors worker.js /api/grants filter)
+    if min_award is not None:
+        filters["award_ceiling"] = {"min": min_award}
+
+    # award_floor.max: floor doesn't exceed the cap
+    if max_award is not None:
+        filters["award_floor"] = {"max": max_award}
+
+    if deadline_before:
+        filters["close_date"] = {"end_date": deadline_before}
+
+    return filters
+
+
+def fetch_page(
+    api_key: str,
+    query: str,
+    page: int,
+    page_size: int,
+    filters: Dict,
+    debug: bool = False,
+) -> Dict:
+    """POST one page to the Simpler Grants.gov search API and return parsed JSON."""
+    payload = json.dumps({
+        "query": query,
+        "filters": filters,
+        "pagination": {
+            "page_offset": page,
+            "page_size": page_size,
+            "sort_order": [{"order_by": "relevancy", "sort_direction": "descending"}],
+        },
+    }).encode()
+
+    req = urllib.request.Request(
+        SIMPLER_API_URL,
+        data=payload,
+        headers={
+            "X-API-Key": api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    context = ssl.create_default_context(cafile=certifi.where())
+    try:
+        with urllib.request.urlopen(req, context=context, timeout=30) as resp:
+            body = resp.read()
+            if debug:
+                logging.debug("Page %d: %d bytes (status %s)", page, len(body), resp.status)
+            return json.loads(body)
+    except urllib.error.HTTPError as err:
+        body_snippet = err.read(200).decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"Simpler Grants API returned {err.code}: {body_snippet!r}"
+        ) from err
+
+
+def fetch_all_opportunities(
+    api_key: str,
+    filters: Dict,
+    query: str = "",
+    limit: Optional[int] = None,
+    debug: bool = False,
+) -> Iterator[Dict]:
+    """Paginate the Simpler Grants.gov API, yielding raw opportunity dicts."""
+    cap = min(limit, MAX_OPPORTUNITIES) if limit is not None else MAX_OPPORTUNITIES
+    fetched = 0
+    for page in range(1, 10_000):
+        if fetched >= cap:
+            break
+        data = fetch_page(api_key, query, page, PAGE_SIZE, filters, debug)
+        opps = data.get("data") or data.get("items") or []
+        if not opps:
+            break
+        for opp in opps:
+            if fetched >= cap:
+                return
+            yield opp
+            fetched += 1
+        logging.info("Page %d: fetched %d total so far", page, fetched)
+        if len(opps) < PAGE_SIZE:
+            break
+
+
+def map_opportunity(opp: Dict) -> Dict[str, str]:
+    """Map a single Simpler Grants.gov API opportunity to the pipeline CSV schema."""
+    summary = opp.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
+
+    opp_id = str(opp.get("opportunity_id") or "")
+    title = (
+        opp.get("opportunity_title")
+        or summary.get("opportunity_title")
+        or "Untitled Grant"
+    )
+    number = opp.get("opportunity_number") or ""
+    agency = (
+        opp.get("agency_name")
+        or summary.get("agency_name")
+        or opp.get("agency_code")
+        or "Unknown Agency"
+    )
+
+    status_raw = (opp.get("opportunity_status") or "").lower()
+    is_forecast = status_raw == "forecasted"
+    stage = "Forecasted" if is_forecast else "Posted"
+
+    fi_list = (
+        opp.get("funding_instruments")
+        or summary.get("funding_instruments")
+        or []
+    )
+    type_raw = fi_list[0] if fi_list else "grant"
+    type_label = type_raw.replace("_", " ").title()
+
+    cfda_list = (
+        opp.get("cfda_numbers")
+        or opp.get("assistance_listing_numbers")
+        or summary.get("assistance_listing_numbers")
+        or []
+    )
+    cfda_str = ", ".join(str(c) for c in cfda_list)
+
+    app_types = opp.get("applicant_types") or summary.get("applicant_types") or []
+    eligible_str = ", ".join(t.replace("_", " ").title() for t in app_types)
+
+    award_floor = opp.get("award_floor") if opp.get("award_floor") is not None else summary.get("award_floor")
+    award_ceiling = opp.get("award_ceiling") if opp.get("award_ceiling") is not None else summary.get("award_ceiling")
+    benefits = _fmt_award(
+        str(award_floor) if award_floor is not None else "",
+        str(award_ceiling) if award_ceiling is not None else "",
+    )
+
+    close_date = opp.get("close_date") or summary.get("close_date") or ""
+    post_date = opp.get("post_date") or summary.get("post_date") or ""
+
+    source_url = f"https://simpler.grants.gov/opportunity/{opp_id}" if opp_id else ""
+
+    relevance_text = " ".join([title, agency, benefits, eligible_str])
+
+    return {
+        "Type": type_label,
+        "Name": title,
+        "Sponsor": agency,
+        "Source URL": source_url,
+        "Region / Eligibility": eligible_str,
+        "Deadline / Next Cohort": close_date,
+        "Cadence": "",
+        "Benefits": benefits,
+        "Eligibility (key conditions)": eligible_str,
+        "Stage": stage,
+        "Non-dilutive?": "Yes",
+        "Stack Required?": "No",
+        "Relevance": _derive_relevance(relevance_text),
+        "Fit": "",
+        "Ease": "",
+        "Opportunity ID": opp_id,
+        "Opportunity Number": number,
+        "CFDA Numbers": cfda_str,
+        "Eligible Applicants": eligible_str,
+        "Award Ceiling": str(award_ceiling) if award_ceiling is not None else "",
+        "Award Floor": str(award_floor) if award_floor is not None else "",
+        "Is Forecast": "1" if is_forecast else "0",
+        "Estimated Post Date": post_date,
+        "Source Channel": "simpler_api",
+    }
+
+
+def write_csv(rows: Iterator[Dict], output_path: str) -> int:
+    """Write mapped rows to a CSV. Returns count of rows written."""
+    out_dir = os.path.dirname(output_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    written = 0
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=OUTPUT_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({col: row.get(col, "") for col in OUTPUT_COLUMNS})
+            written += 1
+    return written
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch grant opportunities from the Simpler Grants.gov API into a pipeline-compatible CSV."
+    )
+    parser.add_argument(
+        "--output", default=DEFAULT_OUTPUT,
+        help=f"Output CSV path (default: {DEFAULT_OUTPUT}).",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Stop after N opportunities (useful for testing).",
+    )
+    parser.add_argument(
+        "--agency-code", dest="agency_codes", action="append", default=None,
+        help="Filter by agency code (repeatable). E.g. --agency-code DOE --agency-code EPA.",
+    )
+    parser.add_argument(
+        "--min-award", type=float, default=None,
+        help="Minimum award ceiling in dollars.",
+    )
+    parser.add_argument(
+        "--max-award", type=float, default=None,
+        help="Maximum award floor in dollars.",
+    )
+    parser.add_argument(
+        "--deadline-before", default=None,
+        help="Only include opportunities closing on or before this date (YYYY-MM-DD).",
+    )
+    parser.add_argument(
+        "--status", choices=["posted", "forecasted", "both"], default="both",
+        help="Opportunity status filter (default: both).",
+    )
+    parser.add_argument(
+        "--query", default="",
+        help="Free-text query (default: empty = all opportunities matching filters).",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Enable debug logging.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    api_key = os.environ.get("SIMPLER_GRANTS_API_KEY", "").strip()
+    if not api_key:
+        logging.error(
+            "SIMPLER_GRANTS_API_KEY environment variable is not set. "
+            "Register at https://simpler.grants.gov to obtain a free API key."
+        )
+        sys.exit(1)
+
+    filters = build_filter_body(
+        agency_codes=args.agency_codes,
+        min_award=args.min_award,
+        max_award=args.max_award,
+        deadline_before=args.deadline_before,
+        status=args.status,
+    )
+    logging.info("Filters: %s", json.dumps(filters))
+
+    raw_opps = fetch_all_opportunities(
+        api_key=api_key,
+        filters=filters,
+        query=args.query,
+        limit=args.limit,
+        debug=args.debug,
+    )
+    rows = (map_opportunity(opp) for opp in raw_opps)
+    count = write_csv(rows, args.output)
+    print(f"OK: wrote {count} opportunit{'y' if count == 1 else 'ies'} to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/worker.js
+++ b/worker.js
@@ -480,7 +480,28 @@ async function checkRateLimit(kv, key) {
   return { blocked: false, rec };
 }
 
-async function fetchFromSimplerGrants(env, query, page = 1, pageSize = 25) {
+const DEFAULT_SIMPLER_FILTERS = {
+  opportunity_status: { one_of: ["posted", "forecasted"] },
+  funding_instrument: { one_of: ["grant", "cooperative_agreement"] },
+};
+
+function buildSimplerGrantsFilters({ agency, minAward, maxAward, deadlineBefore, status }) {
+  const filters = {
+    opportunity_status: { one_of: ["posted", "forecasted"] },
+    funding_instrument: { one_of: ["grant", "cooperative_agreement"] },
+  };
+  if (status === "posted")      filters.opportunity_status = { one_of: ["posted"] };
+  else if (status === "forecasted") filters.opportunity_status = { one_of: ["forecasted"] };
+  if (agency) filters.agency = { one_of: [agency] };
+  // award_ceiling.min: ceiling can reach minAward (mirrors /api/grants filter semantics)
+  if (minAward !== null && !Number.isNaN(minAward)) filters.award_ceiling = { min: minAward };
+  // award_floor.max: floor doesn't exceed maxAward cap
+  if (maxAward !== null && !Number.isNaN(maxAward)) filters.award_floor = { max: maxAward };
+  if (deadlineBefore) filters.close_date = { end_date: deadlineBefore };
+  return filters;
+}
+
+async function fetchFromSimplerGrants(env, query, page = 1, pageSize = 25, filters = null) {
   if (!env.SIMPLER_GRANTS_API_KEY) {
     throw new Error("Missing required credential binding: SIMPLER_GRANTS_API_KEY.");
   }
@@ -492,10 +513,7 @@ async function fetchFromSimplerGrants(env, query, page = 1, pageSize = 25) {
     },
     body: JSON.stringify({
       query,
-      filters: {
-        opportunity_status: { one_of: ["posted", "forecasted"] },
-        funding_instrument: { one_of: ["grant", "cooperative_agreement"] },
-      },
+      filters: filters ?? DEFAULT_SIMPLER_FILTERS,
       pagination: {
         page_offset: page,
         page_size: pageSize,
@@ -518,10 +536,10 @@ const SYNC_PAGE_SIZE = 100;
 // Walks every page of the Simpler Grants.gov search API for `query` (an empty
 // query returns the full catalog matching the filters), stopping when a page
 // comes back short (last page) or SYNC_MAX_OPPORTUNITIES is reached.
-async function fetchAllFromSimplerGrants(env, query) {
+async function fetchAllFromSimplerGrants(env, query, filters = null) {
   const all = [];
   for (let page = 1; all.length < SYNC_MAX_OPPORTUNITIES; page++) {
-    const apiData = await fetchFromSimplerGrants(env, query, page, SYNC_PAGE_SIZE);
+    const apiData = await fetchFromSimplerGrants(env, query, page, SYNC_PAGE_SIZE, filters);
     const opportunities = apiData?.data || apiData?.data?.oppHits || apiData?.items || [];
     all.push(...opportunities);
     if (opportunities.length < SYNC_PAGE_SIZE) break;
@@ -541,37 +559,32 @@ function capitalize(s) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, " ") : "";
 }
 
-async function syncGrantsWithD1(env, query) {
+// Fields that are safe to refresh on every sync (descriptive/structural data
+// from Grants.gov). relevance/fit/ease/weighted_score/non_dilutive/stack_required
+// are deliberately left alone on conflict — they may have been hand-tuned or
+// set by the AI scoring pass, and a resync shouldn't clobber that.
+const REFRESHABLE_SET = `
+    name = excluded.name,
+    type = excluded.type,
+    sponsor = excluded.sponsor,
+    source_url = excluded.source_url,
+    deadline = excluded.deadline,
+    benefits = excluded.benefits,
+    eligibility_conditions = excluded.eligibility_conditions,
+    stage = excluded.stage,
+    cfda_numbers = excluded.cfda_numbers,
+    eligible_applicants = excluded.eligible_applicants,
+    award_ceiling = excluded.award_ceiling,
+    award_floor = excluded.award_floor,
+    source_channel = excluded.source_channel,
+    last_synced_at = excluded.last_synced_at
+`;
+
+async function upsertOpportunitiesToD1(env, opportunities) {
   if (!env.GRANT_MANAGER_DB) {
     throw new Error("D1 binding (GRANT_MANAGER_DB) is missing.");
   }
-  const opportunities = await fetchAllFromSimplerGrants(env, query);
-  if (opportunities.length === 0) {
-    return { success: true, inserted: 0, message: "Sync complete. No records returned from server filters." };
-  }
-
   await env.GRANT_MANAGER_DB.prepare(PROGRAMS_SCHEMA).run();
-
-  // Fields that are safe to refresh on every sync (descriptive/structural data
-  // from Grants.gov). relevance/fit/ease/weighted_score/non_dilutive/stack_required
-  // are deliberately left alone on conflict — they may have been hand-tuned or
-  // set by the AI scoring pass, and a resync shouldn't clobber that.
-  const REFRESHABLE_SET = `
-      name = excluded.name,
-      type = excluded.type,
-      sponsor = excluded.sponsor,
-      source_url = excluded.source_url,
-      deadline = excluded.deadline,
-      benefits = excluded.benefits,
-      eligibility_conditions = excluded.eligibility_conditions,
-      stage = excluded.stage,
-      cfda_numbers = excluded.cfda_numbers,
-      eligible_applicants = excluded.eligible_applicants,
-      award_ceiling = excluded.award_ceiling,
-      award_floor = excluded.award_floor,
-      source_channel = excluded.source_channel,
-      last_synced_at = excluded.last_synced_at
-  `;
 
   const insertStmt = env.GRANT_MANAGER_DB.prepare(`
     INSERT INTO programs (
@@ -631,6 +644,14 @@ async function syncGrantsWithD1(env, query) {
     await env.GRANT_MANAGER_DB.batch(statements.slice(i, i + 50));
   }
   return { success: true, inserted: opportunities.length, message: `Successfully loaded ${opportunities.length} active opportunities to local storage.` };
+}
+
+async function syncGrantsWithD1(env, query) {
+  const opportunities = await fetchAllFromSimplerGrants(env, query);
+  if (opportunities.length === 0) {
+    return { success: true, inserted: 0, message: "Sync complete. No records returned from server filters." };
+  }
+  return upsertOpportunitiesToD1(env, opportunities);
 }
 
 // ===== Anonymous Feedback (GitHub Issues) =====
@@ -1371,6 +1392,107 @@ Example: {"focusAreas":["Health & Medicine","Research & Science"],"orgType":"Non
         log("error", "database_sync_route_failed", { ...reqCtx, error: String(err) });
         return jsonResponse(JSON.stringify({ success: false, error: err.message }), { status: 500 });
       }
+    }
+
+    if (url.pathname === "/api/scan" && request.method === "GET") {
+      if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+      if (!(await isAdminUser(env, username))) return new Response("Forbidden", { status: 403 });
+      if (!env.SIMPLER_GRANTS_API_KEY) {
+        return jsonResponse(JSON.stringify({ error: "Live scan is not configured. Set the SIMPLER_GRANTS_API_KEY secret." }), { status: 503 });
+      }
+      if (!env.GRANT_MANAGER_DB) {
+        return jsonResponse(JSON.stringify({ error: "Database not configured." }), { status: 503 });
+      }
+
+      const agencyParam     = url.searchParams.get("agency") || null;
+      const minAwardRaw     = url.searchParams.get("minAward");
+      const maxAwardRaw     = url.searchParams.get("maxAward");
+      const minAward        = minAwardRaw !== null && minAwardRaw !== "" ? Number(minAwardRaw) : null;
+      const maxAward        = maxAwardRaw !== null && maxAwardRaw !== "" ? Number(maxAwardRaw) : null;
+      const deadlineBefore  = url.searchParams.get("deadlineBefore") || null;
+      const statusParam     = url.searchParams.get("status") || "both";
+      const doSync          = url.searchParams.get("sync") === "true";
+
+      if (!["posted", "forecasted", "both"].includes(statusParam)) {
+        return jsonResponse(JSON.stringify({ error: "status must be posted, forecasted, or both" }), { status: 400 });
+      }
+
+      const appliedFilters = { agency: agencyParam, minAward, maxAward, deadlineBefore, status: statusParam };
+      const apiFilters = buildSimplerGrantsFilters(appliedFilters);
+
+      const scanStart = Date.now();
+      let opportunities;
+      try {
+        opportunities = await fetchAllFromSimplerGrants(env, "", apiFilters);
+      } catch (err) {
+        log("error", "scan_fetch_failed", { ...reqCtx, error: String(err) });
+        return jsonResponse(JSON.stringify({ error: err.message || "Failed to reach Simpler Grants API." }), { status: 502 });
+      }
+
+      // Load user profile for heuristic scoring (same as /api/live-search)
+      let scanProfile = {};
+      if (env.USER_PROFILES) {
+        const rawProfile = await env.USER_PROFILES.get(`profile:${username}`);
+        if (rawProfile) { try { scanProfile = JSON.parse(rawProfile); } catch { scanProfile = {}; } }
+      }
+
+      const results = opportunities.map((opp) => {
+        const summary = opp.summary || opp;
+        const opportunityId = opp.opportunity_id != null ? String(opp.opportunity_id) : "";
+        const name = opp.opportunity_title || summary.opportunity_title || "";
+        const sponsor = opp.agency_name || summary.agency_name || opp.agency_code || "";
+        const awardFloor = opp.award_floor ?? summary.award_floor ?? null;
+        const awardCeiling = opp.award_ceiling ?? summary.award_ceiling ?? null;
+        const applicantTypes = Array.isArray(opp.applicant_types)
+          ? opp.applicant_types
+          : Array.isArray(summary.applicant_types) ? summary.applicant_types : [];
+        const eligibility = applicantTypes.map(capitalize).join(", ");
+        const cfdaList = Array.isArray(opp.cfda_numbers)
+          ? opp.cfda_numbers
+          : Array.isArray(opp.assistance_listing_numbers)
+            ? opp.assistance_listing_numbers
+            : Array.isArray(summary.assistance_listing_numbers)
+              ? summary.assistance_listing_numbers : [];
+        const grant = {
+          "Type":                     capitalize(opp.funding_instrument || summary.funding_instruments?.[0] || "grant"),
+          "Name":                     name,
+          "Sponsor":                  sponsor,
+          "Source URL":               opportunityId ? `https://simpler.grants.gov/opportunity/${opportunityId}` : "",
+          "Region / Eligibility":     eligibility,
+          "Deadline / Next Cohort":   opp.close_date || summary.close_date || "",
+          "Cadence":                  "",
+          "Benefits":                 fmtAward(awardFloor, awardCeiling),
+          "Eligibility (key conditions)": eligibility,
+          "Stage":                    capitalize(opp.opportunity_status || ""),
+          "Non-dilutive?":            "Yes",
+          "Stack Required?":          "No",
+          "Opportunity ID":           opportunityId,
+          "Opportunity Number":       opp.opportunity_number || "",
+          "CFDA Numbers":             cfdaList.join(", "),
+          "Award Ceiling":            awardCeiling,
+          "Award Floor":              awardFloor,
+          "Is Forecast":              (opp.opportunity_status || "").toLowerCase() === "forecasted",
+          "Source Channel":           "simpler_api",
+        };
+        const heuristic = computeLiveHeuristicScores(grant, scanProfile);
+        return { ...grant, Relevance: heuristic.Relevance, Fit: heuristic.Fit, Ease: heuristic.Ease };
+      });
+
+      let syncResult = null;
+      if (doSync) {
+        try {
+          syncResult = await upsertOpportunitiesToD1(env, opportunities);
+        } catch (err) {
+          log("error", "scan_sync_failed", { ...reqCtx, error: String(err) });
+          syncResult = { success: false, error: String(err) };
+        }
+      }
+
+      log("info", "scan_completed", { ...reqCtx, total: results.length, filters: appliedFilters, synced: doSync, durationMs: Date.now() - scanStart });
+
+      const scanBody = { results, total: results.length, filters: appliedFilters };
+      if (syncResult !== null) scanBody.sync = syncResult;
+      return jsonResponse(JSON.stringify(scanBody));
     }
 
     if (url.pathname === "/api/live-search-status") {


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for fetching grant opportunities directly from the Simpler Grants.gov API, including a new admin-only `/api/scan` endpoint for live filtering and optional database synchronization.

## Key Changes

- **New `fetch_grants_api.py` script**: Standalone Python utility to fetch opportunities from Simpler Grants.gov API and export to CSV in the same schema as the existing XML extract pipeline. Supports filtering by agency code, award amounts, deadline, and opportunity status. Includes comprehensive CLI options for testing and production use.

- **Enhanced `worker.js` API filtering**:
  - Extracted filter-building logic into `buildSimplerGrantsFilters()` function to support dynamic filtering by agency, award range, deadline, and status
  - Updated `fetchFromSimplerGrants()` and `fetchAllFromSimplerGrants()` to accept optional filters parameter
  - Refactored database upsert logic into separate `upsertOpportunitiesToD1()` function for reusability

- **New `/api/scan` endpoint**: Admin-only endpoint that:
  - Accepts query parameters for agency, minAward, maxAward, deadlineBefore, and status filtering
  - Fetches matching opportunities from Simpler Grants.gov API in real-time
  - Applies heuristic scoring (Relevance, Fit, Ease) based on user profile
  - Optionally syncs results to D1 database when `sync=true` parameter is provided
  - Returns filtered results with applied filters and optional sync status

- **GitHub Actions workflow update**: Added step to run `fetch_grants_api.py` in the grants-gov-sync workflow, fetching API data alongside existing XML extract

## Implementation Details

- Filter semantics mirror the existing `/api/grants` endpoint behavior (award_ceiling.min for minimum award, award_floor.max for maximum award)
- The `/api/scan` endpoint preserves hand-tuned scoring fields (relevance, fit, ease, weighted_score, non_dilutive, stack_required) on database conflicts
- Both Python and JavaScript implementations use identical filter logic for consistency
- Requires `SIMPLER_GRANTS_API_KEY` environment variable; gracefully handles missing credentials with appropriate error messages

https://claude.ai/code/session_01M2Qb9k1nnak1DpZFKmDE8z