### PR TITLE
feat: summarize grant from source_url via Workers AI

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -651,3 +651,14 @@ export async function addRemediationNote(grantId: number, note: string): Promise
   });
   await handleResponse<{ ok: boolean }>(res);
 }
+
+export interface GrantSummary {
+  summary: string;
+  bullets: string[];
+}
+
+export async function summarizeGrant(sourceUrl: string): Promise<GrantSummary> {
+  const params = new URLSearchParams({ url: sourceUrl });
+  const res = await fetch(`${BASE}/api/summarize?${params}`, { credentials: "include" });
+  return handleResponse<GrantSummary>(res);
+}

--- a/ui/src/components/GrantDrawer.tsx
+++ b/ui/src/components/GrantDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { Grant } from "../types";
 import type { UserProfile } from "../api";
-import { updateNotes } from "../api";
+import { updateNotes, summarizeGrant, type GrantSummary } from "../api";
 import { FOCUS_AREA_KEYWORDS, ORG_TYPE_KEYWORDS, STAGE_KEYWORDS } from "../rankingKeywords";
 import EligibilitySimulator from "./EligibilitySimulator";
 
@@ -209,6 +209,9 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
   const [saved, setSaved] = useState(false);
+  const [summarizing, setSummarizing] = useState(false);
+  const [liveSummary, setLiveSummary] = useState<GrantSummary | null>(null);
+  const [summarizeError, setSummarizeError] = useState("");
   const drawerRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -217,10 +220,27 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
       setNotes(String(grant["Notes/Actions"] || ""));
       setSaved(false);
       setSaveError("");
+      setLiveSummary(null);
+      setSummarizeError("");
       // Move focus into the drawer when it opens
       setTimeout(() => closeBtnRef.current?.focus(), 50);
     }
   }, [grant]);
+
+  async function handleSummarize() {
+    if (!grant || !grant["Source URL"]) return;
+    setSummarizing(true);
+    setSummarizeError("");
+    setLiveSummary(null);
+    try {
+      const result = await summarizeGrant(String(grant["Source URL"]));
+      setLiveSummary(result);
+    } catch (err) {
+      setSummarizeError(err instanceof Error ? err.message : "Summarization failed");
+    } finally {
+      setSummarizing(false);
+    }
+  }
 
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -328,9 +348,9 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
 
             {/* Body */}
             <div className="flex-1 overflow-y-auto p-5 space-y-5">
-              {/* Source URL */}
+              {/* Source URL + Summarize */}
               {grant["Source URL"] && (
-                <div>
+                <div className="flex items-center gap-3 flex-wrap">
                   <a
                     href={String(grant["Source URL"])}
                     target="_blank"
@@ -342,6 +362,52 @@ export default function GrantDrawer({ grant, onClose, onGrantUpdated, watchlist,
                     </svg>
                     View Source
                   </a>
+                  <button
+                    type="button"
+                    onClick={handleSummarize}
+                    disabled={summarizing}
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-300 hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    aria-label="Summarize this grant using AI"
+                  >
+                    {summarizing ? (
+                      <>
+                        <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" aria-hidden="true" />
+                        Summarizing…
+                      </>
+                    ) : (
+                      <>
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                        </svg>
+                        Summarize
+                      </>
+                    )}
+                  </button>
+                </div>
+              )}
+
+              {/* Live summary result */}
+              {(liveSummary || summarizeError) && (
+                <div className="bg-gray-800/50 rounded-lg p-4 space-y-2">
+                  <p className="text-gray-500 text-xs font-medium uppercase tracking-wide">AI Summary</p>
+                  {summarizeError && (
+                    <p className="text-red-400 text-sm">{summarizeError}</p>
+                  )}
+                  {liveSummary && (
+                    <>
+                      <p className="text-gray-300 text-sm leading-snug">{liveSummary.summary}</p>
+                      {liveSummary.bullets.length > 0 && (
+                        <ul className="space-y-1 pt-1">
+                          {liveSummary.bullets.map((b: string, i: number) => (
+                            <li key={i} className="flex items-start gap-2 text-sm text-gray-400">
+                              <span className="text-brand-400 shrink-0 mt-0.5" aria-hidden="true">•</span>
+                              <span>{b}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </>
+                  )}
                 </div>
               )}
 

--- a/worker.js
+++ b/worker.js
@@ -1113,6 +1113,80 @@ Example: {"focusAreas":["Health & Medicine","Research & Science"],"orgType":"Non
       return jsonResponse(JSON.stringify({ configured, provider }));
     }
 
+    if (url.pathname === "/api/summarize" && request.method === "GET") {
+      if (!loggedIn) return new Response("Unauthorized", { status: 401 });
+
+      const sourceUrl = (url.searchParams.get("url") || "").trim();
+      if (!sourceUrl) return jsonResponse(JSON.stringify({ error: "url param required" }), { status: 400 });
+
+      let hostname;
+      try { hostname = new URL(sourceUrl).hostname; } catch {
+        return jsonResponse(JSON.stringify({ error: "Invalid url" }), { status: 400 });
+      }
+      const ALLOWED_HOSTS = [
+        "grants.gov", "simpler.grants.gov", "sam.gov", "beta.sam.gov",
+        "grantsolutions.gov", "nih.gov", "nsf.gov", "sba.gov", "hud.gov",
+        "usda.gov", "ed.gov", "dot.gov", "epa.gov", "energy.gov",
+        "commerce.gov", "treasury.gov", "state.gov", "defense.gov",
+      ];
+      const allowed = ALLOWED_HOSTS.some(h => hostname === h || hostname.endsWith("." + h));
+      if (!allowed) {
+        return jsonResponse(JSON.stringify({ error: "URL domain not allowed for summarization" }), { status: 403 });
+      }
+
+      const hasAI = env.AI || (env.CF_ACCOUNT_ID && env.CF_AI_TOKEN);
+      if (!hasAI) return jsonResponse(JSON.stringify({ error: "AI not configured" }), { status: 503 });
+
+      const pageText = await fetchPageText(sourceUrl);
+      if (!pageText) return jsonResponse(JSON.stringify({ error: "Could not fetch grant page" }), { status: 502 });
+
+      const prompt = `You are a grant research assistant. Summarize the following grant opportunity for a nonprofit or small business applicant.
+
+Grant page content:
+${pageText}
+
+Respond with JSON only — no markdown, no explanation, no extra text:
+{
+  "summary": "<2-3 sentence plain-language summary of what this grant funds, who can apply, and how much is available>",
+  "bullets": ["<key fact 1>", "<key fact 2>", "<key fact 3>", "<key fact 4>", "<key fact 5>"]
+}`;
+
+      const messages = [{ role: "user", content: prompt }];
+      let aiText = "";
+      try {
+        if (env.AI) {
+          const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", { messages, stream: false });
+          aiText = result.response || "";
+        } else {
+          const res = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/ai/run/@cf/meta/llama-3.1-8b-instruct`,
+            { method: "POST", headers: { "Authorization": `Bearer ${env.CF_AI_TOKEN}`, "Content-Type": "application/json" }, body: JSON.stringify({ messages }) }
+          );
+          const data = await res.json();
+          aiText = data.result?.response ?? "";
+        }
+      } catch (err) {
+        log("error", "summarize_ai_error", { ...reqCtx, error: String(err) });
+        return jsonResponse(JSON.stringify({ error: "AI summarization failed" }), { status: 502 });
+      }
+
+      const jsonMatch = aiText.match(/\{[\s\S]*?\}/);
+      if (!jsonMatch) return jsonResponse(JSON.stringify({ error: "Could not parse AI response" }), { status: 502 });
+
+      let parsed;
+      try { parsed = JSON.parse(jsonMatch[0]); } catch {
+        return jsonResponse(JSON.stringify({ error: "Invalid AI JSON" }), { status: 502 });
+      }
+
+      const summary = typeof parsed.summary === "string" ? parsed.summary.slice(0, 600) : "";
+      const bullets = Array.isArray(parsed.bullets)
+        ? parsed.bullets.filter(b => typeof b === "string").slice(0, 5).map(b => String(b).slice(0, 120))
+        : [];
+
+      log("info", "grant_summarized", { ...reqCtx, hostname });
+      return jsonResponse(JSON.stringify({ summary, bullets }));
+    }
+
     if (url.pathname === "/api/grants") {
       if (!loggedIn) {
         return new Response("Unauthorized", { status: 401 });


### PR DESCRIPTION
Adds a /api/summarize endpoint to the Cloudflare Worker that accepts a source_url, fetches its page text using the existing fetchPageText() helper, and asks Workers AI to produce a plain-language summary + key bullets. A domain allowlist restricts fetches to known federal grant hosts (grants.gov, simpler.grants.gov, nih.gov, etc.).

Wires the endpoint into GrantDrawer.tsx as a "Summarize" button next to the "View Source" link. Clicking it calls summarizeGrant() in api.ts, shows a spinner while the AI runs, and renders the result (summary paragraph + bullet list) inline in the drawer — covering both DB grants and live-search results, which already carry a Source URL.